### PR TITLE
Adjusted docs to GitHub pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,6 @@ jobs:
         shell: julia --color=yes --project=docs/ {0}
         run: |
           using Pkg
-          Pkg.add(url="https://github.com/sintefore/TimeStruct.jl")
           Pkg.add(url="https://github.com/EnergyModelsX/EnergyModelsBase.jl")
           Pkg.add(url="https://github.com/EnergyModelsX/EnergyModelsGeography.jl")
           Pkg.develop(PackageSpec(path=pwd()))

--- a/NEWS.md
+++ b/NEWS.md
@@ -53,7 +53,7 @@ Version 0.4.1 (2023-08-02)
 Version 0.4.0 (2023-06-06)
 --------------------------
 ### Switch to TimeStruct.jl
- * Switched the time structure representation to [TimeStruct.jl](https://gitlab.sintef.no/julia-one-sintef/timestruct.jl)
+ * Switched the time structure representation to [TimeStruct.jl](https://github.com/sintefore/TimeStruct.jl)
  * TimeStruct.jl is implemented with only the basis features that were available in TimesStructures.jl. This implies that neither operational nor strategic uncertainty is included in the model
 
 Version 0.3.2 (2023-06-01)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # EnergyModelsInvestments
 
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://energymodelsx.github.io/EnergyModelsInvestments.jl//stable)
+[![In Development](https://img.shields.io/badge/docs-dev-blue.svg)](https://energymodelsx.github.io/EnergyModelsInvestments.jl/dev/)
+
 `EnergyModelsInvestments` is a package to investment decisions to models designed using the [`EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl) package.
 If the package [`EnergyModelsGeography`](https://github.com/EnergyModelsX/EnergyModelsGeography.jl) is loaded, it will also provide investment options to transmission mode.
 

--- a/README.md
+++ b/README.md
@@ -3,19 +3,21 @@
 `EnergyModelsInvestments` is a package to investment decisions to models designed using the [`EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl) package.
 If the package [`EnergyModelsGeography`](https://github.com/EnergyModelsX/EnergyModelsGeography.jl) is loaded, it will also provide investment options to transmission mode.
 
-> **Note**
-> We migrated recently from an internal Git solution to GitHub, including the package [`TimeStruct`](https://github.com/sintefore/TimeStruct.jl). As both `TimeStruct`, `EnergyModelsBase` are not yet registered, it is not possible to build automatically the documentation or run the tests without significant changes in the CI. Every user is however free to build the documentation from the [`docs`](docs) folder.
+> **Note:**
+>
+> We migrated recently from an internal Git solution to GitHub, including the packages [`EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl) and [`EnergyModelsGeography`](https://github.com/EnergyModelsX/EnergyModelsGeography.jl).
+> As both `EnergyModelsBase` and `EnergyModelsGeography` are not yet registered, it is not possible to run the tests without significant changes in the CI.
+> Hence, we plan to wait with creating a release to be certain the tests are running.
+> As a result, the stable docs are not yet available.
+> This may impact as well some links.
 
 ## Usage
 
-The documentation for `EnergyModelsInvestments` is currently not uploaded as we migrated recently to GitHub.
-Once `TimeStruct`, `EnergyModelsBase`, and `EnergyModelsGeography` are registered in the Julia Registry, we will update the README.md  and add the links to the documentation.
-
-See examples of usage of the package and a simple guide for running them in the folder [`examples`](examples).
+The usage of the package is based illustrated through the commented [`examples`](examples).
 
 ## Cite
 
-If you find `EnergyModelsGeography` useful in your work, we kindly request that you cite the following publication:
+If you find `EnergyModelsInvestments` useful in your work, we kindly request that you cite the following publication:
 
 ```@article{boedal_2024,
   title = {Hydrogen for harvesting the potential of offshore wind: A North Sea case study},

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,7 @@
 # EnergyModelsInvestments.jl
 
-This Julia package provides investments for the operational, multi carrier energy model [`EnergyModelsBase.jl`](https://clean_export.pages.sintef.no/energymodelsbase.jl).
+This Julia package provides investment options for the operational, multi carrier energy model [`EnergyModelsBase`](https://energymodelsx.github.io/EnergyModelsBase.jl/).
+It furthermore adds investment options for the transmission modes introduced in [`EnergyModelsGeography`](https://energymodelsx.github.io/EnergyModelsGeography.jl/), if the package is loaded.
 
 ```@docs
 EnergyModelsInvestments

--- a/docs/src/manual/quick-start.md
+++ b/docs/src/manual/quick-start.md
@@ -1,10 +1,10 @@
 # Quick Start
 
-To start using the package, refer to the installation instructions on the README page from the git repository.  
+To start using the package, refer to the installation instructions on the README page from the git repository.
 
-Once the package is installed, you can start using the package. You can start by using an existing model from `EnergyModelsBase` and converting it with investments.
-To achieve this, the model type has to be changed from `OperationalModel` to `InvestmentModel` and additional parameters must be provided (emission penalties and a discount rate).
-New nodes can then be added including investment or investment can be added to existing nodes. To modify an existing node to an investment option, you must provide extra investment data in the field `Data` of your node. This will take the form of an `Array` entry of `InvData` or `InvDataStorage` in case the technology is a storage.
-You can find information about the different investment parameters that can be provided to `InvData` in the following documentation.
+Once the package is installed, you can start using the package. You can start by using an existing model from [`EnergyModelsBase`](https://energymodelsx.github.io/EnergyModelsBase.jl/) and converting it with investments.
+To achieve this, the model type has to be changed from [`OperationalModel`](https://energymodelsx.github.io/EnergyModelsBase.jl/dev/library/public/#Model-and-data) to [`InvestmentModel`](@ref) which requires the addition of a discount rate as parameter.
+New nodes can then be added including investment or investment can be added to existing nodes. To modify an existing node to an investment option, you must provide extra investment data in the field `data` of your node. This will take the form of an `Array` entry of [`InvData`](@ref) or [`InvDataStorage`](@ref) in case the technology is a `Storage` node.
+You can find information about the different investment parameters that can be provided to `InvData` in the documentation by following the links.
 
-You can check out and run the examples provided to see simple cases including investment in technologies and transmission.
+You can check out and run the provided *[examples](@ref examples)* to see simple cases including investment in technologies and transmission.

--- a/docs/src/manual/simple-example.md
+++ b/docs/src/manual/simple-example.md
@@ -1,29 +1,28 @@
-# Example
+# [Examples](@id examples)
 
 For the content of the individual examples, see the [examples](https://gitlab.sintef.no/clean_export/energymodelsinvestments.jl/-/tree/main/examples) directory in the project repository.
 
 ## The package is installed with `] add`
 
-First, add the [*Clean Export* Julia packages repository](https://gitlab.sintef.no/clean_export/registrycleanexport). Then run 
-```
-~/some/directory/ $ julia           # Starts the Julia REPL
-julia> ]                            # Enter Pkg mode 
-pkg> add EnergyModelsInvestments    # Install the package EnergyModelsInvestments to the current environment.
-```
 From the Julia REPL, run
+
 ```julia
 # Starts the Julia REPL
-julia> using EnergyModelsInvestments
+using EnergyModelsInvestments
 # Get the path of the examples directory
-julia> exdir = joinpath(pkgdir(EnergyModelsInvestments), "examples")
+exdir = joinpath(pkgdir(EnergyModelsInvestments), "examples")
 # Include the code into the Julia REPL to run the examples
-julia> include(joinpath(exdir, "sink_source.jl"))
+include(joinpath(exdir, "sink_source.jl"))
+include(joinpath(exdir, "network.jl"))
+include(joinpath(exdir, "geography.jl"))
 ```
-
 
 ## The code was downloaded with `git clone`
 
-First, add the internal [*Clean Export* Julia package registry](https://gitlab.sintef.no/clean_export/registrycleanexport). The examples can then be run from the terminal with
+The examples can be run from the terminal with
+
 ```shell script
 ~/.../energymodelsinvestments.jl/examples $ julia sink_source.jl
+~/.../energymodelsinvestments.jl/examples $ julia network.jl
+~/.../energymodelsinvestments.jl/examples $ julia geography.jl
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,27 +1,39 @@
 # Running the examples
 
-## The package is installed with `] add`
+You have to add the package `EnergyModelsInvestments` to your current project in order to run the example.
+It is not necessary to add the other used packages, as the example is instantiating itself.
+How to add packages is explained in the *[Quick start](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/manual/quick-start/)* of the documentation of `EnergyModelsBase`.
 
-First, add the [*Clean Export* Julia packages repository](https://gitlab.sintef.no/clean_export/registrycleanexport). Then run 
-```
-~/some/directory/ $ julia           # Starts the Julia REPL
-julia> ]                            # Enter Pkg mode 
-pkg> add EnergyModelsInvestments    # Install the package EnergyModelsInvestments to the current environment.
-```
-From the Julia REPL, run
+You can run from the Julia REPL the following code:
+
 ```julia
 # Starts the Julia REPL
-julia> using EnergyModelsInvestments
+using EnergyModelsInvestments
 # Get the path of the examples directory
-julia> exdir = joinpath(pkgdir(EnergyModelsInvestments), "examples")
+exdir = joinpath(pkgdir(EnergyModelsInvestments), "examples")
 # Include the code into the Julia REPL to run the examples
-julia> include(joinpath(exdir, "simple_model.jl"))
+include(joinpath(exdir, "sink_source.jl"))
+include(joinpath(exdir, "network.jl"))
+include(joinpath(exdir, "geography.jl"))
 ```
 
+The *[geography example](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/blob/main/examples/geography.jl)* will be simpliefied in a future version.
+It shows however how investments in transmission mdoes can be included.
+It is hence not as commented as the other examples.
 
-## The code was downloaded with `git clone`
-
-First, add the internal [*Clean Export* Julia package registry](https://gitlab.sintef.no/clean_export/registrycleanexport). The examples can then be run from the terminal with
-```shell script
-~/.../energymodelsinvestments.jl/examples $ julia simple_model.jl
-```
+> **Note**
+>
+> The example is not running yet, as the instantiation would require that the package [`EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl) is registered.
+> It is however possible to run the code directly from a local project in which the packages `TimeStruct`, `EnergyModelsBase`, `EnergyModelsInvestments`, `JuMP`, and `HiGHS` are loaded.
+> In this case, you have to comment lines 2-7 out:
+>
+> ```julia
+> # Activate the test-environment, where HiGHS is added as dependency.
+> Pkg.activate(joinpath(@__DIR__, "../test"))
+> # Install the dependencies.
+> Pkg.instantiate()
+> # Add the package EnergyModelsInvestments to the environment.
+> Pkg.develop(path=joinpath(@__DIR__, ".."))
+> ```
+>
+> If you want to run the *[geography example](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/blob/main/examples/geography.jl)*, you also have to add `EnergyModelsGeography`.

--- a/examples/geography.jl
+++ b/examples/geography.jl
@@ -1,12 +1,10 @@
-if !isequal(splitpath(Base.active_project())[end-1], "test")
-    using Pkg
-    # Activate the test-environment, where PrettyTables and HiGHS are added as dependencies.
-    Pkg.activate(joinpath(@__DIR__, "../test"))
-    # Install the dependencies.
-    Pkg.instantiate()
-    # Add the package EnergyModelsInvestments to the environment.
-    Pkg.develop(path=joinpath(@__DIR__, ".."))
-end
+using Pkg
+# Activate the test-environment, where PrettyTables and HiGHS are added as dependencies.
+Pkg.activate(joinpath(@__DIR__, "../test"))
+# Install the dependencies.
+Pkg.instantiate()
+# Add the package EnergyModelsInvestments to the environment.
+Pkg.develop(path=joinpath(@__DIR__, ".."))
 
 using EnergyModelsBase
 using EnergyModelsGeography
@@ -21,7 +19,7 @@ const EMI = EnergyModelsInvestments
 
 
 function run_model(case, model, optimizer = nothing)
-    @info "Run model" model optimizer
+    @info "Run model"
 
     m = EMG.create_model(case, model)
 
@@ -378,7 +376,11 @@ end
 case_data, modeltype = generate_data()
 
 # Run the optimization as an investment model.
-m = run_model(case_data, modeltype, HiGHS.Optimizer)
+m = run_model(
+    case_data,
+    modeltype,
+    optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true),
+)
 
 # Uncomment to print all the constraints set in the model.
 # print(m)

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -1,240 +1,155 @@
-if !isequal(splitpath(Base.active_project())[end-1], "test")
-    using Pkg
-    # Activate the test-environment, where PrettyTables and HiGHS are added as dependencies.
-    Pkg.activate(joinpath(@__DIR__, "../test"))
-    # Install the dependencies.
-    Pkg.instantiate()
-    # Add the package EnergyModelsInvestments to the environment.
-    Pkg.develop(path=joinpath(@__DIR__, ".."))
-end
+using Pkg
+# Activate the test-environment, where PrettyTables and HiGHS are added as dependencies.
+Pkg.activate(joinpath(@__DIR__, "../test"))
+# Install the dependencies.
+Pkg.instantiate()
+# Add the package EnergyModelsInvestments to the environment.
+Pkg.develop(path=joinpath(@__DIR__, ".."))
 
 using EnergyModelsBase
 using EnergyModelsInvestments
 using HiGHS
 using JuMP
+using PrettyTables
 using TimeStruct
 
 const EMB = EnergyModelsBase
 const EMI = EnergyModelsInvestments
 
-
 """
-    run_model(case, model, optimizer)
-
-Defines the necessary steps for running the model.
-This is a temporary implementation before a separate package handles this.
-"""
-function run_model(case, model, optimizer = nothing)
-    @info "Run model" model optimizer
-
-    m = create_model(case, model)
-
-    set_optimizer(m, optimizer)
-    optimize!(m)
-    return m
-end
-
-
-"""
-    generate_data()
+    generate_network_model()
 
 Generate the data for the case study.
+The example is partly based on the provided example `network.jl` in `EnergyModelsBase`.
 """
-function generate_data()
+function generate_network_model()
     @info "Generate case data"
 
-    # Define the different resources
-    NG = ResourceEmit("NG", 0.2)
+    # Define the different resources and their emission intensity in tCO2/MWh
+    NG = ResourceCarrier("NG", 0.2)
     Coal = ResourceCarrier("Coal", 0.35)
     Power = ResourceCarrier("Power", 0.0)
     CO2 = ResourceEmit("CO2", 1.0)
     products = [NG, Coal, Power, CO2]
 
+    # Variables for the individual entries of the time structure
+    op_duration = 1 # Each operational period has a duration of 1
+    op_number = 24  # There are in total 4 operational periods
+    operational_periods = SimpleTimes(op_number, op_duration)
+
+    # The duration of operational periods per duration of 1 of a strategic period of 8760
+    # implies that a duration of 1 of an operational period corresponds to an hour, while
+    # a duration of 1 of a strategic period corresponds to a year
+    op_per_strat = 8760
+
+    sp_duration = 5 # The duration of a strategic period is given as 5 years
+
+    # Create the time structure It corresponds to simulating one day in a year over
+    # 4 strategic periods
+    T = TwoLevel(4, sp_duration, operational_periods; op_per_strat)
+
+    # Create the global data
+    em_limits = Dict(CO2 => StrategicProfile([450, 400, 350, 300]*365))   # Emission cap for CO2 in t/year
+    em_cost = Dict(CO2 => FixedProfile(0))  # Emission price for CO2 in EUR/t
+    discount_rate = 0.07                    # Discount rate in absolute value
+    model = InvestmentModel(em_limits, em_cost, CO2, discount_rate)
+
+    # Create the individual test nodes, corresponding to a system with an electricity demand/sink,
+    # coal and nautral gas sources, coal and natural gas (with CCS) power plants and CO2 storage.
+    # Only the natural gas power plant and the CO2 storage nodes have ivnestment options
+    op_profile = OperationalProfile([20 20 20 20 25 30 35 35 40 40 40 40 40 35 35 30 25 30 35 30 25 20 20 20])
     nodes = [
-        GenAvailability(1, products),
-        RefSink(
-            2,
-            StrategicProfile([OperationalProfile([20 20 20 20 25 30 35 35 40 40 40 40 40 35 35 30 25 30 35 30 25 20 20 20]),
-                              OperationalProfile([20 20 20 20 25 30 35 35 40 40 40 40 40 35 35 30 25 30 35 30 25 20 20 20]),
-                              OperationalProfile([20 20 20 20 25 30 35 35 40 40 40 40 40 35 35 30 25 30 35 30 25 20 20 20]),
-                              OperationalProfile([20 20 20 20 25 30 35 35 40 40 40 40 40 35 35 30 25 30 35 30 25 20 20 20])]
-            ),
+        GenAvailability(1, products),   # Routing Node
+        RefSink(                        # Demand Node
+            2,                          # Node id
+            op_profile,                 # Used demand profile
             Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
-            Dict(Power => 1),
+            # Line above: Surplus and deficit penalty for the node in EUR/MWh
+            Dict(Power => 1),           # Power demand and corresponding ratio
         ),
-        RefSource(
-            3,
-            FixedProfile(30),
-            FixedProfile(30),
-            FixedProfile(100),
-            Dict(NG => 1),
-            [InvData(
-                capex_cap = FixedProfile(1000),
-                cap_max_inst = FixedProfile(200),
-                cap_max_add = FixedProfile(200),
-                cap_min_add = FixedProfile(10),
-                inv_mode = ContinuousInvestment(),
-                cap_increment = FixedProfile(5),
-                cap_start = 15,
-                ),
-            ],
+        RefSource(                      # Natural gas source
+            3,                          # Node id
+            FixedProfile(80),           # Capacity in MW
+            FixedProfile(30),           # Variable OPEX in EUR/MWh
+            FixedProfile(100),          # Fixed OPEX in EUR/year
+            Dict(NG => 1),              # Output from the Node, in this gase, NG
+            [],                         # Potential additional data, no investment for the source
         ),
-        RefSource(
-            4,
-            FixedProfile(9),
-            FixedProfile(9),
-            FixedProfile(100),
-            Dict(Coal => 1),
-            [InvData(
-                    capex_cap = FixedProfile(1000),
-                    cap_max_inst = FixedProfile(200),
-                    cap_max_add = FixedProfile(200),
-                    cap_min_add = FixedProfile(0),
-                    inv_mode = ContinuousInvestment(),
-                ),
-            ],
+        RefSource(                      # Coal source
+            4,                          # Node id
+            FixedProfile(100),            # Capacity in MW
+            FixedProfile(9),            # Variable OPEX in EUR/MWh
+            FixedProfile(100),          # Fixed OPEX in EUR/year
+            Dict(Coal => 1),            # Output from the Node, in this gase, coal
+            [],                         # Potential additional data, no investment for the source
         ),
-        RefNetworkNode(
-            5,
-            FixedProfile(0),
-            FixedProfile(5.5),
-            FixedProfile(100),
-            Dict(NG => 2),
-            Dict(Power => 1, CO2 => 0),
+        RefNetworkNode(                 # Natural gas power plant with CCS
+            5,                          # Node id
+            FixedProfile(0),            # Capacity in MW, no initial capacity
+            FixedProfile(5.5),          # Variable OPEX in EUR/MWh
+            FixedProfile(1e5),          # Fixed OPEX in EUR/year
+            Dict(NG => 2),              # Input to the node with input ratio
+            Dict(Power => 1, CO2 => 0), # Output from the node with output ratio
+            # Line above: CO2 is required as output for variable definition, but the
+            # value does not matter
             [
                 InvData(
-                    capex_cap = FixedProfile(600),
-                    cap_max_inst = FixedProfile(25),
-                    cap_max_add = FixedProfile(25),
-                    cap_min_add = FixedProfile(0),
-                    inv_mode = ContinuousInvestment(),
+                    capex_cap = FixedProfile(600*1e3),  # Capex in EUR/MW
+                    cap_max_inst = FixedProfile(40),    # Max installed capacity [MW]
+                    cap_max_add = FixedProfile(40),     # Max added capactity per sp [MW]
+                    cap_min_add = FixedProfile(5),     # Min added capactity per sp [MW]
+                    inv_mode = SemiContinuousInvestment(),  # Investment mode
                 ),
-                CaptureEnergyEmissions(0.9),
+                CaptureEnergyEmissions(0.9),            # CO2 capture included for the node
             ],
         ),
-        RefNetworkNode(
-            6,
-            FixedProfile(0),
-            FixedProfile(6),
-            FixedProfile(100),
-            Dict(Coal => 2.5),
-            Dict(Power => 1),
-            [
-                InvData(
-                    capex_cap = FixedProfile(800),
-                    cap_max_inst = FixedProfile(25),
-                    cap_max_add = FixedProfile(25),
-                    cap_min_add = FixedProfile(0),
-                    inv_mode = ContinuousInvestment(),
-                ),
-                EmissionsEnergy(),
-            ],
+        RefNetworkNode(                 # Coal power plant
+            6,                          # Node id
+            FixedProfile(40),           # Capacity in MW
+            FixedProfile(6),            # Variable OPEX in EUR/MWh
+            FixedProfile(0),            # Fixed OPEX in EUR/8h
+            Dict(Coal => 2.5),          # Input to the node with input ratio
+            Dict(Power => 1),           # Output from the node with output ratio
+            [EmissionsEnergy()],        # Additonal data for emissions
         ),
         RefStorage(
-            7,
-            FixedProfile(0),
-            FixedProfile(0),
-            FixedProfile(9.1),
-            FixedProfile(100),
-            CO2,
-            Dict(CO2 => 1, Power => 0.02),
-            Dict(CO2 => 1),
+            7,                          # Node id
+            FixedProfile(0),            # Rate capacity in t/h
+            FixedProfile(1e8),          # Storage capacity in t
+            FixedProfile(9.1),          # Storage variable OPEX for the rate in EUR/t
+            FixedProfile(15*1e3),       # Storage fixed OPEX for the rate in EUR/year
+            CO2,                        # Stored resource
+            Dict(CO2 => 1, Power => 0.02), # Input resource with input ratio
+            # Line above: This implies that storing CO2 requires Power
+            Dict(CO2 => 1),             # Output from the node with output ratio
+            # In practice, for CO2 storage, this is never used.
             [InvDataStorage(
-                    capex_rate = FixedProfile(0),
-                    rate_max_inst = FixedProfile(600),
-                    rate_max_add = FixedProfile(600),
+                    capex_rate = FixedProfile(200*1e3),
+                    rate_max_inst = FixedProfile(60),
+                    rate_max_add = FixedProfile(5),
                     rate_min_add = FixedProfile(0),
-                    capex_stor = FixedProfile(500),
-                    stor_max_inst = FixedProfile(600),
-                    stor_max_add = FixedProfile(600),
+                    capex_stor = FixedProfile(0),
+                    stor_max_inst = FixedProfile(1e9),
+                    stor_max_add = FixedProfile(0),
                     stor_min_add = FixedProfile(0),
                     inv_mode = ContinuousInvestment(),
                 ),
             ],
-        ),
-        RefNetworkNode(
-            8,
-            FixedProfile(2),
-            FixedProfile(0),
-            FixedProfile(0),
-            Dict(Coal => 2.5),
-            Dict(Power => 1),
-            [
-                InvData(
-                    capex_cap = FixedProfile(0),
-                    cap_max_inst = FixedProfile(25),
-                    cap_max_add = FixedProfile(2),
-                    cap_min_add = FixedProfile(2),
-                    inv_mode = ContinuousInvestment(),
-                ),
-                EmissionsEnergy(),
-            ],
-        ),
-        RefStorage(
-            9,
-            FixedProfile(3),
-            FixedProfile(5),
-            FixedProfile(0),
-            FixedProfile(0),
-            CO2,
-            Dict(CO2 => 1, Power => 0.02),
-            Dict(CO2 => 1),
-            [InvDataStorage(
-                    capex_rate = FixedProfile(0),
-                    rate_max_inst = FixedProfile(30),
-                    rate_max_add = FixedProfile(3),
-                    rate_min_add = FixedProfile(3),
-                    capex_stor = FixedProfile(0),
-                    stor_max_inst = FixedProfile(50),
-                    stor_max_add = FixedProfile(5),
-                    stor_min_add = FixedProfile(5),
-                    inv_mode = ContinuousInvestment(),
-                ),
-            ],
-        ),
-        RefNetworkNode(
-            10,
-            FixedProfile(0),
-            FixedProfile(0),
-            FixedProfile(0),
-            Dict(Coal => 2.5),
-            Dict(Power => 1),
-            [
-                InvData(
-                    capex_cap = FixedProfile(10000),
-                    cap_max_inst = FixedProfile(10000),
-                    cap_max_add = FixedProfile(10000),
-                    cap_min_add = FixedProfile(0),
-                    inv_mode = ContinuousInvestment(),
-                ),
-                EmissionsEnergy(),
-            ],
-        ),
+        )
     ]
+
+    # Connect all nodes with the availability node for the overall energy/mass balance
     links = [
+        Direct(12, nodes[1], nodes[2], Linear())
         Direct(15, nodes[1], nodes[5], Linear())
         Direct(16, nodes[1], nodes[6], Linear())
         Direct(17, nodes[1], nodes[7], Linear())
-        Direct(18, nodes[1], nodes[8], Linear())
-        Direct(19, nodes[1], nodes[9], Linear())
-        Direct(110, nodes[1], nodes[10], Linear())
-        Direct(12, nodes[1], nodes[2], Linear())
         Direct(31, nodes[3], nodes[1], Linear())
         Direct(41, nodes[4], nodes[1], Linear())
         Direct(51, nodes[5], nodes[1], Linear())
         Direct(61, nodes[6], nodes[1], Linear())
         Direct(71, nodes[7], nodes[1], Linear())
-        Direct(81, nodes[8], nodes[1], Linear())
-        Direct(91, nodes[9], nodes[1], Linear())
-        Direct(101, nodes[10], nodes[1], Linear())
     ]
-
-    # Creation of the time structure and global data
-    T = TwoLevel(4, 1, SimpleTimes(24, 1))
-    em_limits =
-        Dict(NG => FixedProfile(1e6), CO2 => StrategicProfile([450, 400, 350, 300]))
-    em_cost = Dict(NG => FixedProfile(0), CO2 => FixedProfile(0))
-    modeltype = InvestmentModel(em_limits, em_cost, CO2, 0.07)
 
     # WIP case structure
     case = Dict(
@@ -243,16 +158,32 @@ function generate_data()
         :products => products,
         :T => T,
     )
-    return case, modeltype
+    return case, model
 end
 
 # Generate case data.
-case_data, modeltype = generate_data()
+case, model = generate_network_model()
 
 # Run the optimization as an investment model.
-m = run_model(case_data, modeltype, HiGHS.Optimizer)
+m = EMB.create_model(case, model)
+optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
+set_optimizer(m, optimizer)
+optimize!(m)
 
-# Uncomment to print all the constraints set in the model.
-# print(m)
-
-solution_summary(m)
+# Display some results
+@info "Invested capacity for the natural gas plant in the beginning of the individual strategic periods"
+pretty_table(
+    JuMP.Containers.rowtable(
+        value,
+        m[:cap_add][case[:nodes][5], :];
+        header = [:StrategicPeriod, :InvestCapacity],
+    ),
+)
+@info "Invested capacity for the CO2 storage"
+pretty_table(
+    JuMP.Containers.rowtable(
+        value,
+        m[:stor_rate_add][case[:nodes][7], :];
+        header = [:StrategicPeriod, :InvestCapacity],
+    ),
+)

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -1,12 +1,10 @@
-if !isequal(splitpath(Base.active_project())[end-1], "test")
-    using Pkg
-    # Activate the test-environment, where PrettyTables and HiGHS are added as dependencies.
-    Pkg.activate(joinpath(@__DIR__, "../test"))
-    # Install the dependencies.
-    Pkg.instantiate()
-    # Add the package EnergyModelsInvestments to the environment.
-    Pkg.develop(path=joinpath(@__DIR__, ".."))
-end
+using Pkg
+# Activate the test-environment, where PrettyTables and HiGHS are added as dependencies.
+Pkg.activate(joinpath(@__DIR__, "../test"))
+# Install the dependencies.
+Pkg.instantiate()
+# Add the package EnergyModelsInvestments to the environment.
+Pkg.develop(path=joinpath(@__DIR__, ".."))
 
 using EnergyModelsBase
 using EnergyModelsInvestments
@@ -19,52 +17,73 @@ const EMB = EnergyModelsBase
 const EMI = EnergyModelsInvestments
 const TS = TimeStruct
 
-# Define the required resources
-CO2 = ResourceEmit("CO2", 1.0)
-Power = ResourceCarrier("Power", 0.0)
-products = [Power, CO2]
+function demo_invest(lifemode = RollingLife(); discount_rate = 0.05)
+    @info "Generate case data and run the simple model"
 
-function demo_invest(lifemode = UnlimitedLife(); discount_rate = 0.05)
-    lifetime = FixedProfile(15)
-    sp_dur = 5
+    # Define the different resources and their emission intensity in tCO2/MWh
+    CO2 = ResourceEmit("CO2", 1.0)
+    Power = ResourceCarrier("Power", 0.0)
+    products = [Power, CO2]
 
-    investment_data_source = InvData(
-        capex_cap = FixedProfile(1000), # capex [€/kW]
-        cap_max_inst = FixedProfile(30), #  max installed capacity [kW]
-        cap_max_add = FixedProfile(30), # max_add [kW]
-        cap_min_add = FixedProfile(0), # min_add [kW]
-        life_mode = lifemode,
-        lifetime = lifetime,
-    )
+    # Variables for the individual entries of the time structure
+    op_duration = 2 # Each operational period has a duration of 2
+    op_number = 4   # There are in total 4 operational periods
+    operational_periods = SimpleTimes(op_number, op_duration)
 
-    source = RefSource(
-        "src",
-        FixedProfile(0),
-        FixedProfile(10),
-        FixedProfile(5),
-        Dict(Power => 1),
-        [investment_data_source],
-    )
+    # The duration of operational periods per duration of 1 of a strategic period of 8760
+    # implies that a duration of 1 of an operational period corresponds to an hour, while
+    # a duration of 1 of a strategic period corresponds to a year
+    op_per_strat = 8760
 
-    sink = RefSink(
-        "snk",
-        FixedProfile(20),
-        Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
-        Dict(Power => 1),
-    )
+    sp_duration = 5 # The duration of a strategic period is given as 5 years
 
-    nodes = [GenAvailability(1,products), source, sink]
-    links = [
-        Direct(21, nodes[2], nodes[1], Linear())
-        Direct(13, nodes[1], nodes[3], Linear())
-    ]
+    # Creation of the time structure and global data
+    T = TwoLevel(4, sp_duration, operational_periods; op_per_strat)
 
-    T = TwoLevel(4, sp_dur, SimpleTimes(4, 1))
-    em_limits =
-        Dict(CO2 => StrategicProfile([450, 400, 350, 300]))
-    em_cost = Dict(CO2 => FixedProfile(0))
+    # Create the global data
+    em_limits = Dict(CO2 => FixedProfile(10))   # Emission cap for CO2 in t/8h
+    em_cost = Dict(CO2 => FixedProfile(0))      # Emission price for CO2 in EUR/t
     model = InvestmentModel(em_limits, em_cost, CO2, discount_rate)
 
+    # The lifetime of the technology is 15 years, requiring reinvestment in the
+    # 5th strategic period
+    lifetime = FixedProfile(15)
+
+    # Create the investment data for the source node
+    investment_data_source = InvData(
+        capex_cap = FixedProfile(300*1e3),  # Capex [€/MW]
+        cap_max_inst = FixedProfile(30),    # Max installed capacity [MW]
+        cap_max_add = FixedProfile(30),     # Max added capactity per sp [MW]
+        cap_min_add = FixedProfile(0),      # Max added capactity per sp [MW]
+        life_mode = lifemode,               # Lifetime mode
+        lifetime = lifetime,                # Lifetime
+    )
+
+    # Create the individual test nodes, corresponding to a system with an electricity
+    # demand/sink and source
+    source = RefSource(
+        "source",                   # Node ID
+        FixedProfile(0),            # Capacity in MW
+        FixedProfile(10),           # Variable OPEX in EUR/MW
+        FixedProfile(5),            # Fixed OPEX in EUR/year
+        Dict(Power => 1),           # Output from the Node, in this gase, Power
+        [investment_data_source],   # Additional data used for adding the investment data
+    )
+    sink = RefSink(
+        "sink",                     # Node ID
+        FixedProfile(20),           # Demand in MW
+        Dict(:surplus => FixedProfile(0), :deficit => FixedProfile(1e6)),
+        # Line above: Surplus and deficit penalty for the node in EUR/MWh
+        Dict(Power => 1),           # Power demand and corresponding ratio
+    )
+    nodes = [source, sink]
+
+    # Connect the two ndoes
+    links = [
+        Direct(12, nodes[1], nodes[2], Linear())
+    ]
+
+    # WIP data structure
     case = Dict(
         :nodes => nodes,
         :links => links,
@@ -72,18 +91,27 @@ function demo_invest(lifemode = UnlimitedLife(); discount_rate = 0.05)
         :T => T,
     )
 
-    # Create model and optimize
+    # Create the case and model data and run the model
     m = EMB.create_model(case, model)
     optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
     set_optimizer(m, optimizer)
     optimize!(m)
 
     # Display some results
+    @info "Invested capacity for the source in the beginning of the individual strategic periods"
     pretty_table(
         JuMP.Containers.rowtable(
             value,
-            m[:cap_add];
-            header = [:Source, :StrategicPeriod, :CapInvest],
+            m[:cap_add][source, :];
+            header = [:StrategicPeriod, :InvestCapacity],
+        ),
+    )
+    @info "Retired capacity of the source at the end of the individual strategic periods"
+    pretty_table(
+        JuMP.Containers.rowtable(
+            value,
+            m[:cap_rem][source, :];
+            header = [:StrategicPeriod, :InvestCapacity],
         ),
     )
     return m

--- a/src/EnergyModelsInvestments.jl
+++ b/src/EnergyModelsInvestments.jl
@@ -1,13 +1,13 @@
 """
-Main module for `EnergyModelsInvestments.jl`.
+Main module for `EnergyModelsInvestments`.
 
 This module implements functionalities allowing to run investment analysis.
 
-It is in its current version extending `EnergyModelsBase.jl` and cannot be used as a
+It is in its current version extending `EnergyModelsBase` and cannot be used as a
 stand-alone module.
 
-The extension `EMIGeoExt.jl` includes furthermore the investment options for transmission
-modes as described in `EnergyModelsGeography.jl`.
+The extension `EMIGeoExt` includes furthermore the investment options for transmission
+modes as described in `EnergyModelsGeography`.
 """
 module EnergyModelsInvestments
 

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -2,7 +2,7 @@
 
 This abstract model type should be used when creating additional `EnergyModel` types that
 should utilize investments.
-An example for additional types is given by the inclusion of, *e.g.*, `SDDP.jl`.
+An example for additional types is given by the inclusion of, *e.g.*, `SDDP`.
 """
 abstract type AbstractInvestmentModel <: EMB.EnergyModel end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -9,7 +9,7 @@ Maximize Net Present Value from investments (CAPEX) and operations (OPEX and emi
 Consider adding contributions from
  - revenue (as positive variable, adding positive)
  - maintenance based on usage (as positive variable, adding negative)
-These variables would need to be introduced through the package `SparsVariables.jl`.
+These variables would need to be introduced through the package `SparsVariables`.
 
 Both are not necessary, as it is possible to include them through the OPEX values, but it
 would be beneficial for a better separation and simpler calculations from the results.


### PR DESCRIPTION
The docs still included a significant number of internal links to SINTEF pages.
These links were updated to the corresponding GitHub repositories and their documentation.

In addition, the examples section was updated for simpler runs by the user as well as including both prints to the REPL and commenting the individual node generation.