### PR TITLE
Fixed a bug in offset investments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 Release Notes
+
 =============
+Version 0.5.2 (2024-02-15)
+--------------------------
+### Bugfix
+ * Fixed the function for extracting the field `capex_trans_offset` in `TransInvData`.
 
 Version 0.5.1 (2024-01-17)
 --------------------------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsInvestments"
 uuid = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Dimitri Pinel <Dimitri.Pinel@sintef.no>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/ext/utils.jl
+++ b/ext/utils.jl
@@ -89,14 +89,14 @@ EMI.capex(tm::TransmissionMode, t_inv) = EMI.investment_data(tm).capex_trans[t_i
 
 Returns the offset of the CAPEX of `TransmissionMode` `tm` as `TimeProfile`.
 """
-EMI.capex_offset(tm::TransmissionMode) = EMI.investment_data(tm).capex_trans
+EMI.capex_offset(tm::TransmissionMode) = EMI.investment_data(tm).capex_trans_offset
 
 """
     capex_offset(n::TransmissionMode, t_inv)
 
 Returns the offset of the CAPEX of `TransmissionMode` `tm` in investment period `t_inv`.
 """
-EMI.capex_offset(tm::TransmissionMode, t_inv) = EMI.investment_data(tm).capex_trans[t_inv]
+EMI.capex_offset(tm::TransmissionMode, t_inv) = EMI.investment_data(tm).capex_trans_offset[t_inv]
 
 """
     EMI.increment(tm::TransmissionMode)


### PR DESCRIPTION
The function `EMI.capex_offset` returned the wrong field for transmission investments. This lead to an underestimation of the investment costs into transmission infrastructure.