### PR TITLE
Bugfix in storage investments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Unversioned
  * Fixed a bug when running the examples from a non-cloned version of `EnergyModelsInvestments`.
  * This was achieved through a separate Project.toml in the examples.
  * Fixed a bug for semi-continuous investments for `Storage` nodes.
+ * Fixed a bug for method ambiguity when `Storage` nodes use `DiscreteInvestment`.
 
 Version 0.5.2 (2024-02-15)
 --------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ Unversioned
 --------------------------
  * Fixed a bug when running the examples from a non-cloned version of `EnergyModelsInvestments`.
  * This was achieved through a separate Project.toml in the examples.
+ * Fixed a bug for semi-continuous investments for `Storage` nodes.
 
 Version 0.5.2 (2024-02-15)
 --------------------------

--- a/src/model.jl
+++ b/src/model.jl
@@ -361,11 +361,11 @@ function set_storage_installation(m, n::Storage, 𝒯ᴵⁿᵛ, ::SemiContiInves
 
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
         m[:stor_rate_add][n, t_inv] <=
-            max_add(n, t_inv).rate * m[:stor_cap_invest_b][n, t_inv]
+            max_add(n, t_inv).rate * m[:stor_rate_invest_b][n, t_inv]
     )
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
         m[:stor_rate_add][n, t_inv] >=
-            min_add(n, t_inv).rate * m[:stor_cap_invest_b][n, t_inv]
+            min_add(n, t_inv).rate * m[:stor_rate_invest_b][n, t_inv]
     )
 end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -327,7 +327,7 @@ function set_storage_installation(m, n::Storage, 𝒯ᴵⁿᵛ, ::BinaryInvestme
     )
 end
 
-function set_storage_installation(m, n, 𝒯ᴵⁿᵛ, ::DiscreteInvestment)
+function set_storage_installation(m, n::Storage, 𝒯ᴵⁿᵛ, ::DiscreteInvestment)
     # Set the limits
     for t_inv ∈ 𝒯ᴵⁿᵛ
         set_investment_properties(n, m[:stor_cap_remove_b][n, t_inv])


### PR DESCRIPTION
The binary `stor_cap_invest_b` was used for setting the bounds on `stor_rate_add` instead of the binary `stor_rate_invest_b`. This was fixed.