### PR TITLE
Bugfix: Correction of type ambioguity in start_cap for transmission modes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Version 0.5.3 (2024-03-06)
 
+### Bugfix
+
+* Fixed a bug for the function start_cap in `EMIGeoExt`, where there could be ambiguity with the function start_cap in `EnergyModelsInvestments`.
+
 ### Examples
 
 * Fixed a bug when running the examples from a non-cloned version of `EnergyModelsInvestments`.

--- a/ext/EMIGeoExt/utils.jl
+++ b/ext/EMIGeoExt/utils.jl
@@ -25,7 +25,7 @@ Returns the starting capacity of the `TransmissionMode` `tm` in the first invest
 If no starting capacity is provided in `InvestmentData` (default = Nothing), then use the
 provided capacity from the field `trans_Cap`.
 """
-EMI.start_cap(m, tm::TransmissionMode, t, ::Nothing, modeltype) = tm.trans_cap[t]
+EMI.start_cap(m, tm::TransmissionMode, t, ::Nothing, modeltype::EnergyModel) = tm.trans_cap[t]
 
 
 """


### PR DESCRIPTION
Added specification of type for "modeltype" in function "start_cap" in EMIGeoExt to prevent ambiguity with start_cap definition in EnergyModelsInvestment.


