### PR TITLE
Enhancement of checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,16 +1,18 @@
 # Release notes
 
-## Version 0.5.4 (2024-03-13)
+## Version 0.5.4 (2024-03-21)
+
+### Checks
 
 * Adjusted function `EMB.check_node_data` to changed method call in `EnergyModelsBase`.
 * Allow for jumping over the check regarding the `StrategicProfile` structure in `InvData` and `InvDataStorage` with a conditional argument. The other checks regarding the profiles remain unchanged as a wrong `TimeProfile` there would lead to an error within `TimeStruct`.
 * Moved the checks for strategic indexing to `EnergyModelsBase`.
 
-## Version 0.5.3 (2024-03-06)
-
 ### Bugfix
 
-* Fixed a bug for the function start_cap in `EMIGeoExt`, where there could be ambiguity with the function start_cap in `EnergyModelsInvestments`.
+* Fixed a bug for the function `start_cap` in `EMIGeoExt`, where there could be ambiguity with the function `start_cap` in `EnergyModelsInvestments`.
+
+## Version 0.5.3 (2024-03-06)
 
 ### Examples
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
 # Release notes
 
-## Version 0.5.4 (2024-03-11)
+## Version 0.5.4 (2024-03-13)
 
 * Adjusted function `EMB.check_node_data` to changed method call in `EnergyModelsBase`.
 * Allow for jumping over the check regarding the `StrategicProfile` structure in `InvData` and `InvDataStorage` with a conditional argument. The other checks regarding the profiles remain unchanged as a wrong `TimeProfile` there would lead to an error within `TimeStruct`.
+* Moved the checks for strategic indexing to `EnergyModelsBase`.
 
 ## Version 0.5.3 (2024-03-06)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## Version 0.5.4 (2024-03-11)
+
+* Adjusted function `EMB.check_node_data` to changed method call in `EnergyModelsBase`.
+* Allow for jumping over the check regarding the `StrategicProfile` structure in `InvData` and `InvDataStorage` with a conditional argument. The other checks regarding the profiles remain unchanged as a wrong `TimeProfile` there would lead to an error within `TimeStruct`.
+
 ## Version 0.5.3 (2024-03-06)
 
 ### Bugfix

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsInvestments"
 uuid = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Dimitri Pinel <Dimitri.Pinel@sintef.no>"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
@@ -15,7 +15,7 @@ EnergyModelsGeography = "3f775d88-a4da-46c4-a2cc-aa9f16db6708"
 EMIGeoExt = "EnergyModelsGeography"
 
 [compat]
-EnergyModelsBase = "^0.6.6"
+EnergyModelsBase = "^0.6.7"
 EnergyModelsGeography = "^0.8.0"
 JuMP = "^1.5"
 julia = "^1.9"

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -1,5 +1,5 @@
 """
-    EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel)
+    EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel, check_timeprofiles)
 
 Performs various checks on investment data for standard nodes.
 
@@ -16,7 +16,7 @@ Performs various checks on investment data for standard nodes.
 If `cap_start` is `nothing`, it also checks that the the field `:cap` of the node `n` \
 is not including `OperationalProfile`, `RepresentativeProfile`, or `ScenarioProfile`.
 """
-function EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel)
+function EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel, check_timeprofiles)
 
     inv_data = filter(data -> typeof(data) <: InvestmentData, node_data(n))
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
@@ -33,7 +33,7 @@ function EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype:
         isa(time_profile, FixedProfile) && continue
         message = "are not allowed for the field: "*String(field_name)
 
-        if isa(time_profile, StrategicProfile)
+        if isa(time_profile, StrategicProfile) && check_timeprofiles
             @assert_or_log(
                 length(time_profile.vals) == length(𝒯ᴵⁿᵛ),
                 "Field '" * string(field_name) * "' does not match the strategic structure."
@@ -68,7 +68,7 @@ function EMB.check_node_data(n::EMB.Node, data::InvestmentData, 𝒯, modeltype:
 
 end
 """
-    EMB.check_node_data(n::Storage, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel)
+    EMB.check_node_data(n::Storage, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel, check_timeprofiles)
 
 Performs various checks on investment data for standard nodes. It is similar to the standard
 check nodes functions, but adds checks on
@@ -91,7 +91,7 @@ If `rate_start` is `nothing`, it also checks that the the field `:stor_rate` of 
 If `stor_start` is `nothing`, it also checks that the the field `:stor_cap` of the node \
 `n` is not including `OperationalProfile`, `RepresentativeProfile`, or `ScenarioProfile`.
 """
-function EMB.check_node_data(n::Storage, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel)
+function EMB.check_node_data(n::Storage, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel, check_timeprofiles)
 
     inv_data = filter(data -> typeof(data) <: InvestmentData, node_data(n))
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
@@ -117,7 +117,7 @@ function EMB.check_node_data(n::Storage, data::InvestmentData, 𝒯, modeltype::
         isa(time_profile, FixedProfile) && continue
         message = "are not allowed for the field: "*String(field_name)
 
-        if isa(time_profile, StrategicProfile)
+        if isa(time_profile, StrategicProfile) && check_timeprofiles
             @assert_or_log(
                 length(time_profile.vals) == length(𝒯ᴵⁿᵛ),
                 "Field '" * string(field_name) * "' does not match the strategic structure."

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -7,7 +7,7 @@ EMB.TEST_ENV = true
     # - EMB.check_node_data(n::EMB.Node, data::InvData, 𝒯, modeltype::AbstractInvestmentModel)
     @testset "InvData" begin
 
-        function run_simple_graph(max_add)
+        function run_simple_graph(max_add; check_timeprofiles=true)
             investment_data_source = [InvData(
                 capex_cap       = FixedProfile(1000),       # capex [€/kW]
                 cap_max_inst    = FixedProfile(30),         # max installed capacity [kW]
@@ -21,10 +21,8 @@ EMB.TEST_ENV = true
             )
             case, modeltype = small_graph(;inv_data)
 
-            return optimize(case, modeltype)
+            return optimize(case, modeltype; check_timeprofiles)
         end
-
-
         demand_profile = FixedProfile(20)
 
         # Check that we receive an error if we provide two `InvestmentData`
@@ -69,6 +67,17 @@ EMB.TEST_ENV = true
         @test_throws AssertionError run_simple_graph(max_add)
         max_add = StrategicProfile([rprofile, rprofile, rprofile, rprofile])
         @test_throws AssertionError run_simple_graph(max_add)
+
+        max_add = StrategicProfile([4])
+        msg = "Checking of the time profiles is deactivated:\n" *
+        "Deactivating the checks for the time profiles is strongly discouraged.\n" *
+        "While the model will still run, unexpected results can occur, as well as\n" *
+        "inconsistent case data.\n\n" *
+        "Deactivating the checks for the timeprofiles should only be considered,\n" *
+        "when testing new components. In all other instances, it is recommended to\n" *
+        "provide the correct timeprofiles using a preprocessing routine. \n\n" *
+        "If timeprofiles are not checked, inconsistencies can occur."
+        @test_logs (:warn, msg) run_simple_graph(max_add; check_timeprofiles=false)
 
         # Check that we receive an error if the capacity is an operational profile
         investment_data_source = [InvData(
@@ -153,7 +162,7 @@ EMB.TEST_ENV = true
     # - EMB.check_node_data(n::EMB.Storage, data::InvestmentData, 𝒯, modeltype::AbstractInvestmentModel)
     @testset "InvDataStorage" begin
 
-        function run_simple_graph(rate_max_add, stor_max_add)
+        function run_simple_graph(rate_max_add, stor_max_add; check_timeprofiles=true)
             inv_data = [InvDataStorage(
                 capex_rate = FixedProfile(20),
                 rate_max_inst = FixedProfile(30),
@@ -167,7 +176,7 @@ EMB.TEST_ENV = true
             )]
             case, modeltype = small_graph_stor(;inv_data)
 
-            return optimize(case, modeltype)
+            return optimize(case, modeltype; check_timeprofiles)
         end
 
         # Check that we receive an error if we provide the wrong `InvestmentData`
@@ -250,6 +259,18 @@ EMB.TEST_ENV = true
         @test_throws AssertionError run_simple_graph(rate_max_add, stor_max_add)
         stor_max_add = StrategicProfile([rprofile, rprofile, rprofile, rprofile])
         @test_throws AssertionError run_simple_graph(rate_max_add, stor_max_add)
+
+        stor_max_add = StrategicProfile([4])
+        msg = "Checking of the time profiles is deactivated:\n" *
+        "Deactivating the checks for the time profiles is strongly discouraged.\n" *
+        "While the model will still run, unexpected results can occur, as well as\n" *
+        "inconsistent case data.\n\n" *
+        "Deactivating the checks for the timeprofiles should only be considered,\n" *
+        "when testing new components. In all other instances, it is recommended to\n" *
+        "provide the correct timeprofiles using a preprocessing routine. \n\n" *
+        "If timeprofiles are not checked, inconsistencies can occur."
+        @test_logs (:warn, msg) run_simple_graph(rate_max_add, stor_max_add; check_timeprofiles=false)
+
 
         # Check that we receive an error if the capacity is an operational profile
         rate_cap = OperationalProfile(ones(4))

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -70,12 +70,12 @@ EMB.TEST_ENV = true
 
         max_add = StrategicProfile([4])
         msg = "Checking of the time profiles is deactivated:\n" *
-        "Deactivating the checks for the time profiles is strongly discouraged.\n" *
-        "While the model will still run, unexpected results can occur, as well as\n" *
+        "Deactivating the checks for the time profiles is strongly discouraged. " *
+        "While the model will still run, unexpected results can occur, as well as " *
         "inconsistent case data.\n\n" *
-        "Deactivating the checks for the timeprofiles should only be considered,\n" *
-        "when testing new components. In all other instances, it is recommended to\n" *
-        "provide the correct timeprofiles using a preprocessing routine. \n\n" *
+        "Deactivating the checks for the timeprofiles should only be considered, " *
+        "when testing new components. In all other instances, it is recommended to " *
+        "provide the correct timeprofiles using a preprocessing routine.\n\n" *
         "If timeprofiles are not checked, inconsistencies can occur."
         @test_logs (:warn, msg) run_simple_graph(max_add; check_timeprofiles=false)
 
@@ -250,7 +250,7 @@ EMB.TEST_ENV = true
         @test_throws AssertionError run_simple_graph(rate_max_add, stor_max_add)
         stor_max_add = rprofile
         @test_throws AssertionError run_simple_graph(rate_max_add, stor_max_add)
-        stor_max_add = StrategicProfile([4])
+        stor_max_add = StrategicProfile([6])
         @test_throws AssertionError run_simple_graph(rate_max_add, stor_max_add)
 
         stor_max_add = StrategicProfile([oprofile, oprofile, oprofile, oprofile])
@@ -260,14 +260,14 @@ EMB.TEST_ENV = true
         stor_max_add = StrategicProfile([rprofile, rprofile, rprofile, rprofile])
         @test_throws AssertionError run_simple_graph(rate_max_add, stor_max_add)
 
-        stor_max_add = StrategicProfile([4])
+        stor_max_add = StrategicProfile([6])
         msg = "Checking of the time profiles is deactivated:\n" *
-        "Deactivating the checks for the time profiles is strongly discouraged.\n" *
-        "While the model will still run, unexpected results can occur, as well as\n" *
+        "Deactivating the checks for the time profiles is strongly discouraged. " *
+        "While the model will still run, unexpected results can occur, as well as " *
         "inconsistent case data.\n\n" *
-        "Deactivating the checks for the timeprofiles should only be considered,\n" *
-        "when testing new components. In all other instances, it is recommended to\n" *
-        "provide the correct timeprofiles using a preprocessing routine. \n\n" *
+        "Deactivating the checks for the timeprofiles should only be considered, " *
+        "when testing new components. In all other instances, it is recommended to " *
+        "provide the correct timeprofiles using a preprocessing routine.\n\n" *
         "If timeprofiles are not checked, inconsistencies can occur."
         @test_logs (:warn, msg) run_simple_graph(rate_max_add, stor_max_add; check_timeprofiles=false)
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -7,8 +7,8 @@ const OPTIMIZER = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => tru
 
 Optimize the `case`.
 """
-function optimize(case, modeltype)
-    m = EMB.create_model(case, modeltype)
+function optimize(case, modeltype; check_timeprofiles=true)
+    m = EMB.create_model(case, modeltype; check_timeprofiles)
     set_optimizer(m, OPTIMIZER)
     optimize!(m)
     return m


### PR DESCRIPTION
The checks received also in `EnergyModelsInvestments` the potential to skip the `TimeProfile` check. In addition, the profile checks for investment data, *i.e.*, the checks for identifying potential problems with indexing where moved to `EnergyModelsBase`.