### PR TITLE
[docs] fix link to examples directory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## Unversioned
+
+* Updated a link in the documentation for the examples.
+
 ## Version 0.5.4 (2024-03-21)
 
 ### Checks

--- a/docs/src/manual/simple-example.md
+++ b/docs/src/manual/simple-example.md
@@ -1,6 +1,6 @@
 # [Examples](@id examples)
 
-For the content of the individual examples, see the [examples](https://gitlab.sintef.no/clean_export/energymodelsinvestments.jl/-/tree/main/examples) directory in the project repository.
+For the content of the individual examples, see the [examples](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/tree/main/examples) directory in the project repository.
 
 ## The package is installed with `] add`
 


### PR DESCRIPTION
Fixed a link in the documentation after a [PR ](https://github.com/EnergyModelsX/EnergyModelsGeography.jl/pull/15 )for the JOSS review.