### PR TITLE
Added how to contribute section to docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 * Updated a link in the documentation for the examples.
+* Provided a contribution section in the documentation.
 
 ## Version 0.5.4 (2024-03-21)
 
@@ -30,7 +31,7 @@
 
 ### Checks
 
-* Updated the check systems based on changes introduced in [EnergyModelsBase v 0.6.6](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.6.6).
+* Updated the check systems based on changes introduced in [`EnergyModelsBase` v 0.6.6](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.6.6).
 * Included tests for all checks to be certain that the checks are providing the required output.
 
 ### Tests
@@ -72,7 +73,7 @@ In addition this version includes:
 
 ### Bugfix
 
-* Added strategic period duration multiplication for emissions prices
+* Added strategic period duration multiplication for emissions prices.
 
 ## Version 0.4.5 (2023-10-24)
 
@@ -90,40 +91,40 @@ In addition this version includes:
 
 ### Bugfix
 
-* Bugfix from v0.4.1 `RollingLife` was reverted due to rebasing in v0.4.2. This was fixed
+* Bugfix from v0.4.1 `RollingLife` was reverted due to rebasing in v0.4.2. This was fixed.
 
 ## Version 0.4.2 (2023-08-24)
 
 ### Changes in discounting
 
-* Previously, strategic periods were discounted using the start year for both OPEX and CAPEX
-* This was changed for OPEX and emission cost calculations to account for longer strategic periods
+* Previously, strategic periods were discounted using the start year for both OPEX and CAPEX.
+* This was changed for OPEX and emission cost calculations to account for longer strategic periods.
 
 ## Version 0.4.1 (2023-08-02)
 
 ### Bugfix
 
-* Included calling of `strategic_periods` in `::RollingLife` which was missing
+* Included calling of `strategic_periods` in `::RollingLife` which was missing.
 
 ## Version 0.4.0 (2023-06-06)
 
 ### Switch to TimeStruct.jl
 
-* Switched the time structure representation to [TimeStruct.jl](https://github.com/sintefore/TimeStruct.jl)
-* TimeStruct.jl is implemented with only the basis features that were available in TimesStructures.jl. This implies that neither operational nor strategic uncertainty is included in the model
+* Switched the time structure representation to [`TimeStruct`](https://github.com/sintefore/TimeStruct.jl)
+* `TimeStruct` is implemented with only the basis features that were available in `TimeStructures`, This implies that neither operational nor strategic uncertainty is included in the model.
 
 ## Version 0.3.2 (2023-06-01)
 
-* Bugfix related to `FixedInvestment`
+* Bugfix related to `FixedInvestment`.
 
 ## Version 0.3.1 (2023-06-01)
 
-* Added dispatch on `EMI.has_investment` in the extension instead of defining a new, local function
+* Added dispatch on `EMI.has_investment` in the extension instead of defining a new, local function.
 
 ## Version 0.3.0 (2023-05-xx)
 
-* Adjustment to changes in `EnergyModelsBase` v0.4.0 and `EnergyModelsGeography` v 0.6.0
-* The new filter method for data can be used as example for subsequent usage of `Array{Data}`
+* Adjustment to changes in `EnergyModelsBase` v0.4.0 and `EnergyModelsGeography` v 0.6.0.
+* The new filter method for data can be used as example for subsequent usage of `Array{Data}`.
 * Migrate from Requires.jl to support for weak dependencies in julia v1.9.
 
 ## Version 0.2.8 (2023-05-15)
@@ -132,37 +133,37 @@ In addition this version includes:
 
 ## Version 0.2.7 (2023-04-27)
 
-* Requirements changed to ^0.5.0 for `EnergyModelsGeography`
+* Requirements changed to ^0.5.0 for `EnergyModelsGeography`.
 
 ## Version 0.2.6 (2023-04-24)
 
-* Introduction of abstract type `InvestmentData` as subtype of `Data` to dispatch specifically on data related to investments
-* Changes in the individual utility functions for improved utilization of the multiple dispatch
+* Introduction of abstract type `InvestmentData` as subtype of `Data` to dispatch specifically on data related to investments.
+* Changes in the individual utility functions for improved utilization of the multiple dispatch.
 
 ## Version 0.2.5 (2023-04-18)
 
 * Bugfix related to constraint on `cap_use`,  `stor_rate_use`, and `stor_level`:
   * The variables are constrained using the function `constraints_capacity` and in addition in `constraints_capacity_invest` and `constraints_storage_invest` with the latter constraint being inconsistent for `Sink` nodes.
-  * The constraint in `EnergyModelsInvestments` was therefore removed
+  * The constraint in `EnergyModelsInvestments` was therefore removed.
 
 ## Version 0.2.4 (2023-03-31)
 
-* Removal of type `ContinuousFixedInvestment` as this can be represented with `ContinuousInvestment` and `Cap_max_add` limited to a given period
-* Introduction of abstract type `SemiContiInvestment` and composite type `SemiContinuousOffsetInvestment` to introduce semi-continuous investments in which the cost function has an offset. This is only included for Transmission in the first step
+* Removal of type `ContinuousFixedInvestment` as this can be represented with `ContinuousInvestment` and `Cap_max_add` limited to a given period.
+* Introduction of abstract type `SemiContiInvestment` and composite type `SemiContinuousOffsetInvestment` to introduce semi-continuous investments in which the cost function has an offset. This is only included for Transmission in the first step.
 
 ## Version 0.2.3 (2023-03-20)
 
-* Adjustments in tests and functions to changes introduced in `EnergyModelsGeography` version 0.4.0
+* Adjustments in tests and functions to changes introduced in `EnergyModelsGeography` version 0.4.0.
 
 ## Version 0.2.2 (2023-02-17)
 
-* Adjustments in tests and functions to changes introduced in `EnergyModelsGeography` version 0.3.1
+* Adjustments in tests and functions to changes introduced in `EnergyModelsGeography` version 0.3.1.
 
 ## Version 0.2.1 (2023-02-06)
 
 * Renaming of investment modes:
-  * Rename `DiscreteInvestment` to `BinaryInvestment`
-  * Rename `IntegerInvestment` to `DiscreteInvestment`
+  * Rename `DiscreteInvestment` to `BinaryInvestment`.
+  * Rename `IntegerInvestment` to `DiscreteInvestment`.
 
 ## Version 0.2.0 (2023-02-03)
 
@@ -170,40 +171,40 @@ In addition this version includes:
 
 Adjustment to version 0.3.0, namely:
 
-* Changed type (`Node`) calls in tests to be consistent with version 0.3.0
-* Changed call of function for the creation of `Storage` variables
-* Removal of the type `GlobalData` and replacement with fields in the type `InvestmentModel` in all tests
+* Changed type (`Node`) calls in tests to be consistent with version 0.3.0.
+* Changed call of function for the creation of `Storage` variables.
+* Removal of the type `GlobalData` and replacement with fields in the type `InvestmentModel` in all tests.
 
 ## Version 0.1.5 (2022-12-12)
 
 ### Internal release
 
-* Update Readme
+* Update Readme.
 
 ## Version 0.1.4 (2022-12-09)
 
 ### Changes in naming
 
-* Renamed dictionary keys from `EnergyModelsInvestments` to `Investments`
+* Renamed dictionary keys from `EnergyModelsInvestments` to `Investments`.
 
 ## Version 0.1.3 (2022-30-11)
 
 ### Renamed to EnergyModelsInvestments
 
-* Renamed for more internally consistent package names
+* Renamed for more internally consistent package names.
 
 ## Version 0.1.2 (2021-09-07)
 
 ### Changes in naming
 
-* Major changes in both variable and parameter naming, check the commit message for an overview
+* Major changes in both variable and parameter naming, check the commit message for an overview.
 
 ## Version 0.1.1 (2021-08-20)
 
-* Inclusion for investment in storage (energy)
-* Changes to the datastructures
+* Inclusion for investment in storage (energy).
+* Changes to the datastructures.
 
 ## Version 0.1.0 (2021-07-06)
 
-* Initial version
-* Inclusion of discounting
+* Initial version.
+* Inclusion of discounting.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,7 @@ news = "docs/src/manual/NEWS.md"
 cp("NEWS.md", news; force=true)
 
 makedocs(
-    sitename = "EnergyModelsInvestments.jl",
+    sitename = "EnergyModelsInvestments",
     format = Documenter.HTML(
         prettyurls=get(ENV, "CI", "false") == "true",
         edit_link="main",
@@ -29,6 +29,9 @@ makedocs(
             "Optimization variables" => "manual/optimization-variables.md",
             "Example" => "manual/simple-example.md",
             "Release notes" => "manual/NEWS.md",
+        ],
+        "How to" => Any[
+            "Contribute to EnergyModelsInvestments" => "how-to/contribute.md",
         ],
         "Library" => Any[
             "Public" => "library/public.md",

--- a/docs/src/how-to/contribute.md
+++ b/docs/src/how-to/contribute.md
@@ -1,0 +1,42 @@
+# Contribute to EnergyModelsInvestments
+
+Contributing to `EnergyModelsInvestments` can be achieved in several different ways.
+
+## File a bug report
+
+Another approach to contributing to `EnergyModelsInvestments` is through filing a bug report as an [_issue_](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/issues/new) when unexpected behaviour is occuring.
+
+When filing a bug report, please follow the following guidelines:
+
+1. Be certain that the bug is a bug and originating in `EnergyModelsInvestments`:
+    - If the problem is within the results of the optimization problem, please check first that the nodes are correctly linked with each other.
+      Frequently, missing links (or wrongly defined links) restrict the transport of energy/mass.
+      If you are certain that all links are set correctly, it is most likely a bug in `EnergyModelsInvestments` and should be reported.
+    - If the problem occurs in model construction, it is most likely a bug  in either `EnergyModelsBase` or `EnergyModelsInvestments` and should be reported in the respective package.
+      The error message of Julia should provide you with the failing function and whether the failing function is located in `EnergyModelsBase` or `EnergyModelsInvestments`.
+      It can occur, that the last shown failing function is within `JuMP` or `MathOptInterface`.
+      In this case, it is best to trace the error to the last called `EnergyModelsBase` or `EnergyModelsInvestments` function.
+    - If the problem is only appearing for specific solvers, it is most likely not a bug in `EnergyModelsInvestments`, but instead a problem of the solver wrapper for `MathOptInterface`.
+      In this case, please contact the developers of the corresponding solver wrapper.
+2. Label the issue as bug, and
+3. Provide a minimum working example of a case in which the bug occurs.
+
+!!! note
+    We are aware that certain design choices within `EnergyModelsInvestments` can lead to method ambiguities.
+    Our aim is to extend the documentation to improve the description on how to best extend the base functionality as well as which caveats can occur.
+
+    In order to improve the code, we welcome any reports of potential method ambiguities to help us improving the structure of the framework.
+
+## Feature requests
+
+`EnergyModelsInvestments` includes several `Investment` options and `LifetimeMode`s.
+However, not all potential options are included.
+Hence, if you require a new investment or lifetime mode, it is best to provide a feature request.
+
+Feature requests for `EnergyModelsInvestments` should follow the guidelines developed for [`EnergyModelsBase`](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/how-to/contribute/).
+
+!!! note
+    `EnergyModelsInvestments` is slightly different than `EnergyModelsBase`.
+
+    Contrary to the other package, we consider that it is beneficial to have all potential features of investment decisions within `EnergyModelsInvestments`.
+    Hence, requiring a new `Investment` mode or `LifetimeMode` should be addressed directly to `EnergyModelsInvestments` through creating an [_issue_](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/issues/new).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,4 @@
-# EnergyModelsInvestments.jl
+# EnergyModelsInvestments
 
 This Julia package provides investment options for the operational, multi carrier energy model [`EnergyModelsBase`](https://energymodelsx.github.io/EnergyModelsBase.jl/).
 It furthermore adds investment options for the transmission modes introduced in [`EnergyModelsGeography`](https://energymodelsx.github.io/EnergyModelsGeography.jl/), if the package is loaded.
@@ -18,6 +18,14 @@ Pages = [
     "manual/philosophy.md",
     "manual/optimization-variables.md",
     "manual/simple-example.md",
+]
+```
+
+## How to guides
+
+```@contents
+Pages = [
+    "how-to/contribute.md",
 ]
 ```
 


### PR DESCRIPTION
The contribution section is similar as the one in [`EnergyModelsBase`](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/how-to/contribute/), but focuses on the specific contribution options for `EnergyModelsInvestments`.

This PR corresponds to the request from the [JOSS submission](https://github.com/EnergyModelsX/EnergyModelsBase.jl/issues/21). 