### PR TITLE
Fix: OPEX contribution with varying length of strategic periods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
 # Release notes
 
-## Unversioned
+## Version 0.5.5 (2024-05-02)
+
+### Bugfix
+
+* Fixed two bugs in the calculation of the OPEX contribution to the objective function for `TransmissionMode`:
+  * Switched to average discounting and
+  * Added the multiplication of the OPEX contribution with `duration(t_inv)` to account for varying lengths of strategic periods.
+
+### Miscellaneous
 
 * Updated a link in the documentation for the examples.
 * Provided a contribution section in the documentation.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsInvestments"
 uuid = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Dimitri Pinel <Dimitri.Pinel@sintef.no>"]
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/ext/EMIGeoExt/model.jl
+++ b/ext/EMIGeoExt/model.jl
@@ -22,8 +22,8 @@ function EMG.update_objective(m, 𝒯, ℳ, modeltype::EMI.AbstractInvestmentMod
         if tm in ℳᴵⁿᵛ
             obj -= objective_weight(t_inv, disc) * m[:capex_trans][tm, t_inv]
         end
-        obj -= duration(t_inv) * objective_weight(t_inv, disc) * m[:trans_opex_fixed][tm, t_inv]
-        obj -= duration(t_inv) * objective_weight(t_inv, disc) * m[:trans_opex_var][tm, t_inv]
+        obj -= duration(t_inv) * objective_weight(t_inv, disc, type="avg") * m[:trans_opex_fixed][tm, t_inv]
+        obj -= duration(t_inv) * objective_weight(t_inv, disc, type="avg") * m[:trans_opex_var][tm, t_inv]
     end
 
     @objective(m, Max, obj)

--- a/ext/EMIGeoExt/model.jl
+++ b/ext/EMIGeoExt/model.jl
@@ -22,8 +22,8 @@ function EMG.update_objective(m, 𝒯, ℳ, modeltype::EMI.AbstractInvestmentMod
         if tm in ℳᴵⁿᵛ
             obj -= objective_weight(t_inv, disc) * m[:capex_trans][tm, t_inv]
         end
-        obj -= objective_weight(t_inv, disc) * m[:trans_opex_fixed][tm, t_inv]
-        obj -= objective_weight(t_inv, disc) * m[:trans_opex_var][tm, t_inv]
+        obj -= duration(t_inv) * objective_weight(t_inv, disc) * m[:trans_opex_fixed][tm, t_inv]
+        obj -= duration(t_inv) * objective_weight(t_inv, disc) * m[:trans_opex_var][tm, t_inv]
     end
 
     @objective(m, Max, obj)


### PR DESCRIPTION
Multiply transmission opex with `duration(t_inv)` in the `update_objective` function for the EMIGeo extension.