### PR TITLE
Change how investment mode is handled

### DIFF
--- a/examples/geography.jl
+++ b/examples/geography.jl
@@ -283,16 +283,14 @@ function get_sub_system_data(
                     charge = NoStartInvData(
                         capex = FixedProfile(500),
                         max_inst = FixedProfile(600),
-                        max_add = FixedProfile(600),
-                        min_add = FixedProfile(0),
-                        inv_mode = ContinuousInvestment(),
+                        inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(0)),
+                        life_mode = UnlimitedLife(),
                     ),
                     level = NoStartInvData(
                         capex = FixedProfile(500),
                         max_inst = FixedProfile(600),
-                        max_add = FixedProfile(600),
-                        min_add = FixedProfile(0),
-                        inv_mode = ContinuousInvestment(),
+                        inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(0)),
+                        life_mode = UnlimitedLife(),
                     )
                 ),
             ],
@@ -325,16 +323,14 @@ function get_sub_system_data(
                     charge = NoStartInvData(
                         capex = FixedProfile(500),
                         max_inst = FixedProfile(30),
-                        max_add = FixedProfile(3),
-                        min_add = FixedProfile(0),
-                        inv_mode = ContinuousInvestment(),
+                        inv_mode = ContinuousInvestment(FixedProfile(3), FixedProfile(0)),
+                        life_mode = UnlimitedLife(),
                     ),
                     level = NoStartInvData(
                         capex = FixedProfile(500),
                         max_inst = FixedProfile(50),
-                        max_add = FixedProfile(2),
-                        min_add = FixedProfile(0),
-                        inv_mode = ContinuousInvestment(),
+                        inv_mode = ContinuousInvestment(FixedProfile(2), FixedProfile(0)),
+                        life_mode = UnlimitedLife(),
                     )
                 ),
             ],

--- a/examples/geography.jl
+++ b/examples/geography.jl
@@ -281,16 +281,16 @@ function get_sub_system_data(
             [
                 StorageInvData(
                     charge = NoStartInvData(
-                        capex = FixedProfile(500),
-                        max_inst = FixedProfile(600),
-                        inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(0)),
-                        life_mode = UnlimitedLife(),
+                        FixedProfile(500),
+                        FixedProfile(600),
+                        ContinuousInvestment(FixedProfile(0), FixedProfile(600)),
+                        UnlimitedLife(),
                     ),
                     level = NoStartInvData(
-                        capex = FixedProfile(500),
-                        max_inst = FixedProfile(600),
-                        inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(0)),
-                        life_mode = UnlimitedLife(),
+                        FixedProfile(500),
+                        FixedProfile(600),
+                        ContinuousInvestment(FixedProfile(0), FixedProfile(600)),
+                        UnlimitedLife(),
                     )
                 ),
             ],
@@ -321,16 +321,16 @@ function get_sub_system_data(
             [
                 StorageInvData(
                     charge = NoStartInvData(
-                        capex = FixedProfile(500),
-                        max_inst = FixedProfile(30),
-                        inv_mode = ContinuousInvestment(FixedProfile(3), FixedProfile(0)),
-                        life_mode = UnlimitedLife(),
+                        FixedProfile(500),
+                        FixedProfile(30),
+                        ContinuousInvestment(FixedProfile(0), FixedProfile(3)),
+                        UnlimitedLife(),
                     ),
                     level = NoStartInvData(
-                        capex = FixedProfile(500),
-                        max_inst = FixedProfile(50),
-                        inv_mode = ContinuousInvestment(FixedProfile(2), FixedProfile(0)),
-                        life_mode = UnlimitedLife(),
+                        FixedProfile(500),
+                        FixedProfile(50),
+                        ContinuousInvestment(FixedProfile(0), FixedProfile(2)),
+                        UnlimitedLife(),
                     )
                 ),
             ],

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -89,7 +89,7 @@ function generate_example_data()
             # value does not matter
             [
                 InvData(
-                    capex_cap = FixedProfile(600*1e3),  # Capex in EUR/MW
+                    capex_cap = FixedProfile(600*1e3),  # CAPEX [EUR/MW]
                     cap_max_inst = FixedProfile(40),    # Max installed capacity [MW]
                     cap_max_add = FixedProfile(40),     # Max added capactity per sp [MW]
                     cap_min_add = FixedProfile(5),     # Min added capactity per sp [MW]
@@ -123,10 +123,13 @@ function generate_example_data()
             [
                 StorageInvData(
                     charge = NoStartInvData(
-                        capex = FixedProfile(200*1e3),
-                        max_inst = FixedProfile(60),
-                        inv_mode = ContinuousInvestment(FixedProfile(5), FixedProfile(0)),
-                        life_mode = UnlimitedLife(),
+                        FixedProfile(200*1e3),  # CAPEX [EUR/(t/h)]
+                        FixedProfile(60),       # Max installed capacity [EUR/(t/h)]
+                        ContinuousInvestment(FixedProfile(0), FixedProfile(5)),
+                        # Line above: Investment mode with the following arguments:
+                        # 1. argument: min added capactity per sp [t/h]
+                        # 2. argument: max added capactity per sp [t/h]
+                        UnlimitedLife(),        # Lifetime mode
                     )
                 )
             ],

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -125,16 +125,8 @@ function generate_example_data()
                     charge = NoStartInvData(
                         capex = FixedProfile(200*1e3),
                         max_inst = FixedProfile(60),
-                        max_add = FixedProfile(5),
-                        min_add = FixedProfile(0),
-                        inv_mode = ContinuousInvestment(),
-                    ),
-                    level = NoStartInvData(
-                        capex = FixedProfile(0),
-                        max_inst = FixedProfile(1e9),
-                        max_add = FixedProfile(0),
-                        min_add = FixedProfile(0),
-                        inv_mode = ContinuousInvestment(),
+                        inv_mode = ContinuousInvestment(FixedProfile(5), FixedProfile(0)),
+                        life_mode = UnlimitedLife(),
                     )
                 )
             ],

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -120,10 +120,10 @@ function EMB.check_node_data(
     end
 
     for cap_fields ∈ fieldnames(typeof(data))
-        inv_data = getfield(data, cap_fields)
-        isnothing(inv_data) && continue
+        sub_data = getfield(data, cap_fields)
+        isnothing(sub_data) && continue
         check_inv_data(
-            inv_data,
+            sub_data,
             capacity(getproperty(n, cap_fields)),
             𝒯,
             " of field `" * String(cap_fields) * "`",

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -71,14 +71,14 @@ The increment for the discrete investment can be different for the individual st
 periods.
 
 # Fields
-- **`max_add::TimeProfile`** is the maximum added capacity in a strategic period.
 - **`min_add::TimeProfile`** is the minimum added capacity in a strategic period. In the
   case of `ContinuousInvestment`, this implies that the model **must** invest at least
   in this capacity in each strategic period.
+- **`max_add::TimeProfile`** is the maximum added capacity in a strategic period.
 """
 struct ContinuousInvestment <: Investment
-    max_add::TimeProfile
     min_add::TimeProfile
+    max_add::TimeProfile
 end
 """
     FixedInvestment <: Investment
@@ -110,15 +110,15 @@ still linear dependent on the
 Semi-continuous investments introduce one binary variable for each strategic period.
 
 # Fields
-- **`max_add::TimeProfile`** is the maximum added capacity in a strategic period.
 - **`min_add::TimeProfile`** is the minimum added capacity in a strategic period. In the
   case of `SemiContinuousInvestment`, this implies that the model **must** invest at least
   in this capacity in each strategic period. The model can also choose not too invest at
   all.
+- **`max_add::TimeProfile`** is the maximum added capacity in a strategic period.
 """
 struct SemiContinuousInvestment <: SemiContiInvestment
-    max_add::TimeProfile
     min_add::TimeProfile
+    max_add::TimeProfile
 end
 
 """
@@ -139,8 +139,8 @@ Semi-continuous investments introduce one binary variable for each strategic per
 - **`capex_offset::TimeProfile`** is offset for the CAPEX in a strategic period.
 """
 struct SemiContinuousOffsetInvestment <: SemiContiInvestment
-    max_add::TimeProfile
     min_add::TimeProfile
+    max_add::TimeProfile
     capex_offset::TimeProfile
 end
 
@@ -270,7 +270,7 @@ Hence, the name of the parameters have to be specified.
   alternatives can be used: [`UnlimitedLife`](@ref), [`StudyLife`](@ref), [`PeriodLife`](@ref)
   or [`RollingLife`](@ref).
 """
-@kwdef struct NoStartInvData <: GeneralInvData
+struct NoStartInvData <: GeneralInvData
     capex::TimeProfile
     max_inst::TimeProfile
     inv_mode::Investment
@@ -290,7 +290,7 @@ Hence, the name of the parameters have to be specified.
 # Fields in addition to [`NoStartInvData`](@ref)
 - **`initial::Real`** is the initial capacity.
 """
-@kwdef struct StartInvData <: GeneralInvData
+struct StartInvData <: GeneralInvData
     capex::TimeProfile
     max_inst::TimeProfile
     initial::Real

--- a/src/legacy_constructor.jl
+++ b/src/legacy_constructor.jl
@@ -50,11 +50,11 @@ function InvDataStorage(;
         inv_mode_rate = DiscreteInvestment(rate_increment)
         inv_mode_cap = DiscreteInvestment(stor_increment)
     elseif isa(inv_mode, ContinuousInvestment)
-        inv_mode_rate = ContinuousInvestment(rate_max_add, rate_min_add)
-        inv_mode_cap = ContinuousInvestment(stor_max_add, stor_min_add)
+        inv_mode_rate = ContinuousInvestment(rate_min_add, rate_max_add)
+        inv_mode_cap = ContinuousInvestment(stor_min_add, stor_max_add)
     elseif isa(inv_mode, SemiContinuousInvestment)
-        inv_mode_rate = SemiContinuousInvestment(rate_max_add, rate_min_add)
-        inv_mode_cap = SemiContinuousInvestment(stor_max_add, stor_min_add)
+        inv_mode_rate = SemiContinuousInvestment(rate_min_add, rate_max_add)
+        inv_mode_cap = SemiContinuousInvestment(stor_min_add, stor_max_add)
     end
 
     # Create the new lifetime mode structures
@@ -71,34 +71,34 @@ function InvDataStorage(;
     # Create the new generalized investment data
     if isnothing(rate_start)
         charge_type = NoStartInvData(
-            capex = capex_rate,
-            max_inst = rate_max_inst,
-            inv_mode = inv_mode_rate,
-            life_mode = tmp_life_mode,
+            capex_rate,
+            rate_max_inst,
+            inv_mode_rate,
+            tmp_life_mode,
         )
     else
         charge_type = StartInvData(
-            capex = capex_rate,
-            max_inst = rate_max_inst,
-            initial = rate_start,
-            inv_mode = inv_mode_rate,
-            life_mode = tmp_life_mode,
+            capex_rate,
+            rate_max_inst,
+            rate_start,
+            inv_mode_rate,
+            tmp_life_mode,
         )
     end
     if isnothing(stor_start)
         level_type = NoStartInvData(
-            capex = capex_stor,
-            max_inst = stor_max_inst,
-            inv_mode = inv_mode_cap,
-            life_mode = tmp_life_mode,
+            capex_stor,
+            stor_max_inst,
+            inv_mode_cap,
+            tmp_life_mode,
         )
     else
         level_type = StartInvData(
-            capex = capex_stor,
-            max_inst = stor_max_inst,
-            initial = stor_start,
-            inv_mode = inv_mode_cap,
-            life_mode = tmp_life_mode,
+            capex_stor,
+            stor_max_inst,
+            stor_start,
+            inv_mode_cap,
+            tmp_life_mode,
         )
     end
 

--- a/src/legacy_constructor.jl
+++ b/src/legacy_constructor.jl
@@ -39,52 +39,66 @@ function InvDataStorage(;
         "(https://energymodelsx.github.io/EnergyModelsRenewableProducers.jl/stable/library/public/#EnergyModelsRenewableProducers.HydroStor)."
     )
 
+    # Create the new investment mode structures
+    if isa(inv_mode, BinaryInvestment)
+        inv_mode_rate = BinaryInvestment()
+        inv_mode_cap = BinaryInvestment()
+    elseif isa(inv_mode, FixedInvestment)
+        inv_mode_rate = FixedInvestment()
+        inv_mode_cap = FixedInvestment()
+    elseif isa(inv_mode, DiscreteInvestment)
+        inv_mode_rate = DiscreteInvestment(rate_increment)
+        inv_mode_cap = DiscreteInvestment(stor_increment)
+    elseif isa(inv_mode, ContinuousInvestment)
+        inv_mode_rate = ContinuousInvestment(rate_max_add, rate_min_add)
+        inv_mode_cap = ContinuousInvestment(stor_max_add, stor_min_add)
+    elseif isa(inv_mode, SemiContinuousInvestment)
+        inv_mode_rate = SemiContinuousInvestment(rate_max_add, rate_min_add)
+        inv_mode_cap = SemiContinuousInvestment(stor_max_add, stor_min_add)
+    end
+
+    # Create the new lifetime mode structures
+    if isa(life_mode, UnlimitedLife)
+        tmp_life_mode = UnlimitedLife()
+    elseif isa(life_mode, StudyLife)
+        tmp_life_mode = StudyLife(lifetime)
+    elseif isa(life_mode, PeriodLife)
+        tmp_life_mode = PeriodLife(lifetime)
+    elseif isa(life_mode, RollingLife)
+        tmp_life_mode = RollingLife(lifetime)
+    end
+
+    # Create the new generalized investment data
     if isnothing(rate_start)
         charge_type = NoStartInvData(
             capex = capex_rate,
             max_inst = rate_max_inst,
-            max_add = rate_max_add,
-            min_add = rate_min_add,
-            inv_mode = inv_mode,
-            increment = rate_increment,
-            life_mode = life_mode,
-            lifetime = lifetime,
+            inv_mode = inv_mode_rate,
+            life_mode = tmp_life_mode,
         )
     else
         charge_type = StartInvData(
             capex = capex_rate,
             max_inst = rate_max_inst,
-            max_add = rate_max_add,
-            min_add = rate_min_add,
             initial = rate_start,
-            inv_mode = inv_mode,
-            increment = rate_increment,
-            life_mode = life_mode,
-            lifetime = lifetime,
+            inv_mode = inv_mode_rate,
+            life_mode = tmp_life_mode,
         )
     end
     if isnothing(stor_start)
         level_type = NoStartInvData(
             capex = capex_stor,
             max_inst = stor_max_inst,
-            max_add = stor_max_add,
-            min_add = stor_min_add,
-            inv_mode = inv_mode,
-            increment = stor_increment,
-            life_mode = life_mode,
-            lifetime = lifetime,
+            inv_mode = inv_mode_cap,
+            life_mode = tmp_life_mode,
         )
     else
         level_type = StartInvData(
             capex = capex_stor,
             max_inst = stor_max_inst,
-            max_add = stor_max_add,
-            min_add = stor_min_add,
             initial = stor_start,
-            inv_mode = inv_mode,
-            increment = stor_increment,
-            life_mode = life_mode,
-            lifetime = lifetime,
+            inv_mode = inv_mode_cap,
+            life_mode = tmp_life_mode,
         )
     end
 
@@ -93,3 +107,12 @@ function InvDataStorage(;
         level = level_type,
     )
 end
+
+DiscreteInvestment() = DiscreteInvestment(FixedProfile(0))
+ContinuousInvestment() = ContinuousInvestment(FixedProfile(0), FixedProfile(0))
+SemiContinuousInvestment() = SemiContinuousInvestment(FixedProfile(0), FixedProfile(0))
+SemiContinuousOffsetInvestment() = SemiContinuousOffsetInvestment(FixedProfile(0), FixedProfile(0), FixedProfile(0))
+
+StudyLife() = StudyLife(FixedProfile(0))
+PeriodLife() = PeriodLife(FixedProfile(0))
+RollingLife() = RollingLife(FixedProfile(0))

--- a/src/model.jl
+++ b/src/model.jl
@@ -243,7 +243,7 @@ function add_investment_constraints(m, n, inv_data, cap, prefix, 𝒯, modeltype
     set_capacity_cost(m, n, inv_data, prefix, 𝒯ᴵⁿᵛ, modeltype)
 
     # Constraints for minimum investments
-    set_capacity_installation(m, n, inv_data, cap, prefix, 𝒯ᴵⁿᵛ)
+    set_capacity_installation(m, n, cap, prefix, 𝒯ᴵⁿᵛ)
 end
 
 
@@ -319,23 +319,23 @@ function set_capacity_installation(m, n, 𝒯ᴵⁿᵛ, ::FixedInvestment)
 end
 
 """
-    set_storage_installation(m, n, 𝒯ᴵⁿᵛ)
+    set_capacity_installation(m, n, field, prefix, 𝒯ᴵⁿᵛ)
 
-Add constraints related to storage installation depending on investment mode of node `n`
+Add constraints related to installation depending on investment mode of type `n`.
 """
-set_capacity_installation(m, n, inv_data, cap, prefix, 𝒯ᴵⁿᵛ) =
-    set_capacity_installation(m, n, inv_data, cap, prefix, 𝒯ᴵⁿᵛ, investment_mode(inv_data))
+set_capacity_installation(m, n, cap, prefix, 𝒯ᴵⁿᵛ) =
+    set_capacity_installation(m, n, cap, prefix, 𝒯ᴵⁿᵛ, investment_mode(n, cap))
 
-function set_capacity_installation(m, n, inv_data, cap, prefix, 𝒯ᴵⁿᵛ, ::Investment)
+function set_capacity_installation(m, n, cap, prefix, 𝒯ᴵⁿᵛ, inv_mode::Investment)
     # Deduce the required variable
     var_add = get_var_add(m, prefix, n)
 
     # Set the limits
-    @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_add[t_inv] <= max_add(inv_data, t_inv))
-    @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_add[t_inv] >= min_add(inv_data, t_inv))
+    @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_add[t_inv] <= max_add(inv_mode, t_inv))
+    @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_add[t_inv] >= min_add(inv_mode, t_inv))
 end
 
-function set_capacity_installation(m, n, inv_data, cap, prefix, 𝒯ᴵⁿᵛ, ::BinaryInvestment)
+function set_capacity_installation(m, n, cap, prefix, 𝒯ᴵⁿᵛ, inv_mode::BinaryInvestment)
     # Add the binary variable to the `SparseVariables` containers and add characteristics
     var_invest_b = get_var_invest_b(m, prefix)
     for t_inv ∈ 𝒯ᴵⁿᵛ
@@ -360,7 +360,7 @@ function set_capacity_installation(m, n, inv_data, cap, prefix, 𝒯ᴵⁿᵛ, :
     )
 end
 
-function set_capacity_installation(m, n, inv_data, cap, prefix, 𝒯ᴵⁿᵛ, ::DiscreteInvestment)
+function set_capacity_installation(m, n, cap, prefix, 𝒯ᴵⁿᵛ, inv_mode::DiscreteInvestment)
     # Add the binary variable to the `SparseVariables` containers and add characteristics
     var_invest_b = get_var_invest_b(m, prefix)
     var_remove_b = get_var_remove_b(m, prefix)
@@ -378,15 +378,15 @@ function set_capacity_installation(m, n, inv_data, cap, prefix, 𝒯ᴵⁿᵛ, :
     # Set the limits
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
         var_add[t_inv] ==
-            increment(inv_data, t_inv) * var_invest_b[n, t_inv]
+            increment(inv_mode, t_inv) * var_invest_b[n, t_inv]
     )
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
         var_rem[t_inv] ==
-            increment(inv_data, t_inv) * var_remove_b[n, t_inv]
+            increment(inv_mode, t_inv) * var_remove_b[n, t_inv]
     )
 end
 
-function set_capacity_installation(m, n, inv_data, cap, prefix, 𝒯ᴵⁿᵛ, ::SemiContiInvestment)
+function set_capacity_installation(m, n, cap, prefix, 𝒯ᴵⁿᵛ, inv_mode::SemiContiInvestment)
     # Add the binary variable to the `SparseVariables` containers and add characteristics
     var_invest_b = get_var_invest_b(m, prefix)
     for t_inv ∈ 𝒯ᴵⁿᵛ
@@ -400,15 +400,15 @@ function set_capacity_installation(m, n, inv_data, cap, prefix, 𝒯ᴵⁿᵛ, :
     # Set the limits
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
         var_add[t_inv] <=
-            max_add(inv_data, t_inv) * var_invest_b[n, t_inv]
+            max_add(inv_mode, t_inv) * var_invest_b[n, t_inv]
     )
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],
         var_add[t_inv] >=
-            min_add(inv_data, t_inv) * var_invest_b[n, t_inv]
+            min_add(inv_mode, t_inv) * var_invest_b[n, t_inv]
     )
 end
 
-function set_capacity_installation(m, n, inv_data, cap, prefix, 𝒯ᴵⁿᵛ, ::FixedInvestment)
+function set_capacity_installation(m, n, cap, prefix, 𝒯ᴵⁿᵛ, inv_mode::FixedInvestment)
     # Add the binary variable to the `SparseVariables` containers and add characteristics
     var_invest_b = get_var_invest_b(m, prefix)
     for t_inv ∈ 𝒯ᴵⁿᵛ

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -305,18 +305,29 @@ are unlimited.
 lifetime_mode(inv_data::GeneralInvData) = inv_data.life_mode
 
 """
+    lifetime(lifetime_mode::LifetimeMode)
+
+Return the lifetime of the lifetime mode `lifetime_mode` as `TimeProfile`.
+"""
+lifetime(lifetime_mode::LifetimeMode) = lifetime_mode.lifetime
+"""
     lifetime(inv_data::GeneralInvData)
 
 Return the lifetime of the investment data `inv_data` as `TimeProfile`.
 """
-lifetime(inv_data::GeneralInvData) = inv_data.lifetime
-
+lifetime(inv_data::GeneralInvData) = lifetime(lifetime_mode(inv_data))
 """
-    lifetime(inv_data::GeneralInvData, t)
+    lifetime(lifetime_mode::LifetimeMode, t_inv)
 
-Return the lifetime of the investment data `inv_data` in period `t`.
+Return the lifetime of the lifetime mode `lifetime_mode` in investment period `t_inv`.
 """
-lifetime(inv_data::GeneralInvData, t) = inv_data.lifetime[t]
+lifetime(lifetime_mode::LifetimeMode, t_inv) = lifetime_mode.lifetime[t_inv]
+"""
+    lifetime(inv_data::GeneralInvData, t_inv)
+
+Return the lifetime of the investment data `inv_data` in investment period `t_inv`.
+"""
+lifetime(inv_data::GeneralInvData, t_inv) = lifetime(lifetime_mode(inv_data), t_inv)
 
 start_cap(n, t_inv, inv_data::StartInvData, field, modeltype::EnergyModel) =
     inv_data.initial
@@ -355,47 +366,89 @@ investment period `t_inv`.
 max_installed(inv_data::GeneralInvData, t_inv) = inv_data.max_inst[t_inv]
 
 """
+    max_add(inv_mode::Investment)
+
+Returns the maximum allowed added capacity of the investment mode `inv_mode` as
+`TimeProfile`.
+"""
+max_add(inv_mode::Investment) = inv_mode.max_add
+"""
     max_add(inv_data::GeneralInvData)
 
 Returns the maximum allowed added capacity of the investment data `inv_data` as
 `TimeProfile`.
 """
-max_add(inv_data::GeneralInvData) = inv_data.max_add
+max_add(inv_data::GeneralInvData) = max_add(investment_mode(inv_data))
+"""
+    max_add(inv_mode::Investment, t_inv)
+
+Returns the maximum allowed added capacity of the investment mode `inv_mode` investment
+period `t_inv`.
+"""
+max_add(inv_mode::Investment, t_inv) = inv_mode.max_add[t_inv]
+
 """
     max_add(inv_data::GeneralInvData, t_inv)
 
 Returns the maximum allowed added capacity of the investment data `inv_data` in investment
 period `t_inv`.
 """
-max_add(inv_data::GeneralInvData, t_inv) = inv_data.max_add[t_inv]
+max_add(inv_data::GeneralInvData, t_inv) = max_add(investment_mode(inv_data), t_inv)
 
+"""
+    min_add(inv_mode::Investment)
+
+Returns the minimum allowed added capacity of the investment mode `inv_mode` as
+`TimeProfile`.
+"""
+min_add(inv_mode::Investment) = inv_mode.min_add
 """
     min_add(inv_data::GeneralInvData)
 
 Returns the minimum allowed added capacity of the investment data `inv_data` as
 `TimeProfile`.
 """
-min_add(inv_data::GeneralInvData) = inv_data.min_add
+min_add(inv_data::GeneralInvData) = min_add(investment_mode(inv_data))
+"""
+    min_add(inv_mode::Investment, t_inv)
+
+Returns the minimum allowed added capacity of the investment mode `inv_mode` in investment
+period `t_inv`.
+"""
+min_add(inv_mode::Investment, t_inv) = inv_mode.min_add[t_inv]
+
 """
     min_add(inv_data::GeneralInvData, t_inv)
 
 Returns the minimum allowed added capacity of the investment data `inv_data` in investment
 period `t_inv`.
 """
-min_add(inv_data::GeneralInvData, t_inv) = inv_data.min_add[t_inv]
+min_add(inv_data::GeneralInvData, t_inv) = min_add(investment_mode(inv_data), t_inv)
 
+"""
+    increment(inv_mode::Investment)
+
+Returns the capacity increment of the investment mode `inv_mode` as `TimeProfile`.
+"""
+increment(inv_mode::Investment) = inv_mode.increment
 """
     increment(inv_data::GeneralInvData)
 
 Returns the capacity increment of the investment data `inv_data` as `TimeProfile`.
 """
-increment(inv_data::GeneralInvData) = inv_data.increment
+increment(inv_data::GeneralInvData) = increment(investment_mode(inv_data))
+"""
+    increment(inv_mode::Investment, t_inv)
+
+Returns the capacity increment of the investment mode `inv_mode` in investment period `t_inv`.
+"""
+increment(inv_mode::Investment, t_inv) = inv_mode.increment[t_inv]
 """
     increment(inv_data::GeneralInvData, t_inv)
 
 Returns the capacity increment of the investment data `inv_data` in investment period `t_inv`.
 """
-increment(inv_data::GeneralInvData, t_inv) = inv_data.increment[t_inv]
+increment(inv_data::GeneralInvData, t_inv) = increment(investment_mode(inv_data), t_inv)
 
 set_capex_value(m, n, inv_data, prefix, 𝒯ᴵⁿᵛ) =
     set_capex_value(m, n, inv_data, prefix, 𝒯ᴵⁿᵛ, investment_mode(inv_data))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -297,6 +297,13 @@ are continuous.
 investment_mode(inv_data::GeneralInvData) = inv_data.inv_mode
 
 """
+    investment_mode(type, field::Symbol)
+
+Return the investment mode of the `Storage` node `n` and the capacity `field`.
+"""
+investment_mode(type, field::Symbol) = investment_mode(investment_data(type, field))
+
+"""
     lifetime_mode(inv_data::GeneralInvData)
 
 Return the lifetime mode of the investment data `inv_data`. By default, all investments

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -168,16 +168,14 @@ EMB.TEST_ENV = true
                     charge = NoStartInvData(
                         capex = FixedProfile(20),
                         max_inst = FixedProfile(30),
-                        max_add = charge_max_add,
-                        min_add = FixedProfile(5),
-                        inv_mode = ContinuousInvestment(),
+                        inv_mode = ContinuousInvestment(charge_max_add, FixedProfile(5)),
+                        life_mode = UnlimitedLife(),
                     ),
                     level = NoStartInvData(
                         capex = FixedProfile(500),
                         max_inst = FixedProfile(600),
-                        max_add = level_max_add,
-                        min_add = FixedProfile(5),
-                        inv_mode = ContinuousInvestment(),
+                        inv_mode = ContinuousInvestment(level_max_add, FixedProfile(5)),
+                        life_mode = UnlimitedLife(),
                     )
                 )
             ]
@@ -204,32 +202,28 @@ EMB.TEST_ENV = true
                 charge = NoStartInvData(
                     capex = FixedProfile(20),
                     max_inst = FixedProfile(30),
-                    max_add = FixedProfile(20),
-                    min_add = FixedProfile(5),
-                    inv_mode = ContinuousInvestment(),
+                    inv_mode = ContinuousInvestment(FixedProfile(20), FixedProfile(5)),
+                    life_mode = UnlimitedLife(),
                 ),
                 level = NoStartInvData(
                     capex = FixedProfile(500),
                     max_inst = FixedProfile(600),
-                    max_add = FixedProfile(600),
-                    min_add = FixedProfile(5),
-                    inv_mode = ContinuousInvestment(),
+                    inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(5)),
+                    life_mode = UnlimitedLife(),
                 )
             ),
             StorageInvData(
                 charge = NoStartInvData(
                     capex = FixedProfile(20),
                     max_inst = FixedProfile(30),
-                    max_add = FixedProfile(20),
-                    min_add = FixedProfile(5),
-                    inv_mode = ContinuousInvestment(),
+                    inv_mode = ContinuousInvestment(FixedProfile(20), FixedProfile(5)),
+                    life_mode = UnlimitedLife(),
                 ),
                 level = NoStartInvData(
                     capex = FixedProfile(500),
                     max_inst = FixedProfile(600),
-                    max_add = FixedProfile(600),
-                    min_add = FixedProfile(5),
-                    inv_mode = ContinuousInvestment(),
+                    inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(5)),
+                    life_mode = UnlimitedLife(),
                 )
             ),
         ]
@@ -307,17 +301,15 @@ EMB.TEST_ENV = true
                 charge = StartInvData(
                     capex = FixedProfile(20),
                     max_inst = FixedProfile(30),
-                    max_add = FixedProfile(20),
-                    min_add = FixedProfile(5),
                     initial = 40,
-                    inv_mode = ContinuousInvestment(),
+                    inv_mode = ContinuousInvestment(FixedProfile(20), FixedProfile(5)),
+                    life_mode = UnlimitedLife(),
                 ),
                 level = NoStartInvData(
                     capex = FixedProfile(500),
                     max_inst = FixedProfile(600),
-                    max_add = FixedProfile(600),
-                    min_add = FixedProfile(5),
-                    inv_mode = ContinuousInvestment(),
+                    inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(5)),
+                    life_mode = UnlimitedLife(),
                 )
             )
         ]
@@ -331,17 +323,15 @@ EMB.TEST_ENV = true
                 charge = NoStartInvData(
                     capex = FixedProfile(20),
                     max_inst = FixedProfile(30),
-                    max_add = FixedProfile(20),
-                    min_add = FixedProfile(5),
-                    inv_mode = ContinuousInvestment(),
+                    inv_mode = ContinuousInvestment(FixedProfile(20), FixedProfile(5)),
+                    life_mode = UnlimitedLife(),
                 ),
                 level = StartInvData(
                     capex = FixedProfile(500),
                     max_inst = FixedProfile(600),
-                    max_add = FixedProfile(600),
-                    min_add = FixedProfile(5),
                     initial = 700,
-                    inv_mode = ContinuousInvestment(),
+                    inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(5)),
+                    life_mode = UnlimitedLife(),
                 )
             )
         ]
@@ -351,7 +341,7 @@ EMB.TEST_ENV = true
         # Check that we receive an error if we provide a larger min_add than max_add
         rate_min_add = 40
         case, modeltype = small_graph_stor(;rate_min_add)
-        @test_throws AssertionError optimize(case, modeltype)
+        @test_throws AssertionError optimize(case, modeltype) # This one, no exception
         stor_min_add = 700
         case, modeltype = small_graph_stor(;stor_min_add)
         @test_throws AssertionError optimize(case, modeltype)

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -166,16 +166,16 @@ EMB.TEST_ENV = true
             inv_data = [
                 StorageInvData(
                     charge = NoStartInvData(
-                        capex = FixedProfile(20),
-                        max_inst = FixedProfile(30),
-                        inv_mode = ContinuousInvestment(charge_max_add, FixedProfile(5)),
-                        life_mode = UnlimitedLife(),
+                        FixedProfile(20),
+                        FixedProfile(30),
+                        ContinuousInvestment(FixedProfile(5), charge_max_add),
+                        UnlimitedLife(),
                     ),
                     level = NoStartInvData(
-                        capex = FixedProfile(500),
-                        max_inst = FixedProfile(600),
-                        inv_mode = ContinuousInvestment(level_max_add, FixedProfile(5)),
-                        life_mode = UnlimitedLife(),
+                        FixedProfile(500),
+                        FixedProfile(600),
+                        ContinuousInvestment(FixedProfile(5), level_max_add),
+                        UnlimitedLife(),
                     )
                 )
             ]
@@ -200,30 +200,30 @@ EMB.TEST_ENV = true
         inv_data = [
             StorageInvData(
                 charge = NoStartInvData(
-                    capex = FixedProfile(20),
-                    max_inst = FixedProfile(30),
-                    inv_mode = ContinuousInvestment(FixedProfile(20), FixedProfile(5)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(20),
+                    FixedProfile(30),
+                    ContinuousInvestment(FixedProfile(5), FixedProfile(20)),
+                    UnlimitedLife(),
                 ),
                 level = NoStartInvData(
-                    capex = FixedProfile(500),
-                    max_inst = FixedProfile(600),
-                    inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(5)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(500),
+                    FixedProfile(600),
+                    ContinuousInvestment(FixedProfile(5), FixedProfile(600)),
+                    UnlimitedLife(),
                 )
             ),
             StorageInvData(
                 charge = NoStartInvData(
-                    capex = FixedProfile(20),
-                    max_inst = FixedProfile(30),
-                    inv_mode = ContinuousInvestment(FixedProfile(20), FixedProfile(5)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(20),
+                    FixedProfile(30),
+                    ContinuousInvestment(FixedProfile(5), FixedProfile(20)),
+                    UnlimitedLife(),
                 ),
                 level = NoStartInvData(
-                    capex = FixedProfile(500),
-                    max_inst = FixedProfile(600),
-                    inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(5)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(500),
+                    FixedProfile(600),
+                    ContinuousInvestment(FixedProfile(5), FixedProfile(600)),
+                    UnlimitedLife(),
                 )
             ),
         ]
@@ -299,17 +299,17 @@ EMB.TEST_ENV = true
         inv_data = [
             StorageInvData(
                 charge = StartInvData(
-                    capex = FixedProfile(20),
-                    max_inst = FixedProfile(30),
-                    initial = 40,
-                    inv_mode = ContinuousInvestment(FixedProfile(20), FixedProfile(5)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(20),
+                    FixedProfile(30),
+                    40,
+                    ContinuousInvestment(FixedProfile(5), FixedProfile(20)),
+                    UnlimitedLife(),
                 ),
                 level = NoStartInvData(
-                    capex = FixedProfile(500),
-                    max_inst = FixedProfile(600),
-                    inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(5)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(500),
+                    FixedProfile(600),
+                    ContinuousInvestment(FixedProfile(5), FixedProfile(600)),
+                    UnlimitedLife(),
                 )
             )
         ]
@@ -321,17 +321,17 @@ EMB.TEST_ENV = true
         inv_data = [
             StorageInvData(
                 charge = NoStartInvData(
-                    capex = FixedProfile(20),
-                    max_inst = FixedProfile(30),
-                    inv_mode = ContinuousInvestment(FixedProfile(20), FixedProfile(5)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(20),
+                    FixedProfile(30),
+                    ContinuousInvestment(FixedProfile(5), FixedProfile(20)),
+                    UnlimitedLife(),
                 ),
                 level = StartInvData(
-                    capex = FixedProfile(500),
-                    max_inst = FixedProfile(600),
-                    initial = 700,
-                    inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(5)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(500),
+                    FixedProfile(600),
+                    700,
+                    ContinuousInvestment(FixedProfile(5), FixedProfile(600)),
+                    UnlimitedLife(),
                 )
             )
         ]

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -264,16 +264,14 @@ end
                 charge = NoStartInvData(
                     capex = FixedProfile(20),
                     max_inst = FixedProfile(30),
-                    max_add = FixedProfile(30),
-                    min_add = FixedProfile(15),
-                    inv_mode = SemiContinuousInvestment(),
+                    inv_mode = SemiContinuousInvestment(FixedProfile(30), FixedProfile(15)),
+                    life_mode = UnlimitedLife(),
                 ),
                 level = NoStartInvData(
                     capex = FixedProfile(500),
                     max_inst = FixedProfile(600),
-                    max_add = FixedProfile(600),
-                    min_add = FixedProfile(150),
-                    inv_mode = SemiContinuousInvestment(),
+                    inv_mode = SemiContinuousInvestment(FixedProfile(600), FixedProfile(150)),
+                    life_mode = UnlimitedLife(),
                 )
             ),
         ]
@@ -323,18 +321,14 @@ end
                 charge = NoStartInvData(
                     capex = FixedProfile(20),
                     max_inst = FixedProfile(30),
-                    max_add = FixedProfile(30),
-                    min_add = FixedProfile(15),
-                    inv_mode = DiscreteInvestment(),
-                    increment = FixedProfile(5),
+                    inv_mode = DiscreteInvestment(FixedProfile(5)),
+                    life_mode = UnlimitedLife(),
                 ),
                 level = NoStartInvData(
                     capex = FixedProfile(500),
                     max_inst = FixedProfile(600),
-                    max_add = FixedProfile(600),
-                    min_add = FixedProfile(150),
-                    inv_mode = DiscreteInvestment(),
-                    increment = FixedProfile(150),
+                    inv_mode = DiscreteInvestment(FixedProfile(150)),
+                    life_mode = UnlimitedLife(),
                 )
             ),
         ]
@@ -380,17 +374,15 @@ end
                 charge = StartInvData(
                     capex = FixedProfile(20),
                     max_inst = FixedProfile(30),
-                    max_add = FixedProfile(30),
-                    min_add = FixedProfile(15),
                     inv_mode = FixedInvestment(),
+                    life_mode = UnlimitedLife(),
                     initial = 0,
                 ),
                 level = StartInvData(
                     capex = FixedProfile(500),
                     max_inst = FixedProfile(600),
-                    max_add = FixedProfile(600),
-                    min_add = FixedProfile(150),
                     inv_mode = FixedInvestment(),
+                    life_mode = UnlimitedLife(),
                     initial = 0,
                 )
             ),
@@ -438,18 +430,16 @@ end
                 charge = StartInvData(
                     capex = FixedProfile(20),
                     max_inst = FixedProfile(30),
-                    max_add = FixedProfile(30),
-                    min_add = FixedProfile(15),
-                    inv_mode = BinaryInvestment(),
                     initial = 0,
+                    inv_mode = BinaryInvestment(),
+                    life_mode = UnlimitedLife(),
                 ),
                 level = StartInvData(
                     capex = FixedProfile(500),
                     max_inst = FixedProfile(600),
-                    max_add = FixedProfile(600),
-                    min_add = FixedProfile(150),
-                    inv_mode = BinaryInvestment(),
                     initial = 0,
+                    inv_mode = BinaryInvestment(),
+                    life_mode = UnlimitedLife(),
                 )
             ),
         ]

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -262,16 +262,16 @@ end
         inv_data = [
             StorageInvData(
                 charge = NoStartInvData(
-                    capex = FixedProfile(20),
-                    max_inst = FixedProfile(30),
-                    inv_mode = SemiContinuousInvestment(FixedProfile(30), FixedProfile(15)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(20),
+                    FixedProfile(30),
+                    SemiContinuousInvestment(FixedProfile(15), FixedProfile(30)),
+                    UnlimitedLife(),
                 ),
                 level = NoStartInvData(
-                    capex = FixedProfile(500),
-                    max_inst = FixedProfile(600),
-                    inv_mode = SemiContinuousInvestment(FixedProfile(600), FixedProfile(150)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(500),
+                    FixedProfile(600),
+                    SemiContinuousInvestment(FixedProfile(150), FixedProfile(600)),
+                    UnlimitedLife(),
                 )
             ),
         ]
@@ -319,16 +319,16 @@ end
         inv_data = [
             StorageInvData(
                 charge = NoStartInvData(
-                    capex = FixedProfile(20),
-                    max_inst = FixedProfile(30),
-                    inv_mode = DiscreteInvestment(FixedProfile(5)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(20),
+                    FixedProfile(30),
+                    DiscreteInvestment(FixedProfile(5)),
+                    UnlimitedLife(),
                 ),
                 level = NoStartInvData(
-                    capex = FixedProfile(500),
-                    max_inst = FixedProfile(600),
-                    inv_mode = DiscreteInvestment(FixedProfile(150)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(500),
+                    FixedProfile(600),
+                    DiscreteInvestment(FixedProfile(150)),
+                    UnlimitedLife(),
                 )
             ),
         ]
@@ -372,18 +372,18 @@ end
         inv_data = [
             StorageInvData(
                 charge = StartInvData(
-                    capex = FixedProfile(20),
-                    max_inst = FixedProfile(30),
-                    inv_mode = FixedInvestment(),
-                    life_mode = UnlimitedLife(),
-                    initial = 0,
+                    FixedProfile(20),
+                    FixedProfile(30),
+                    0,
+                    FixedInvestment(),
+                    UnlimitedLife(),
                 ),
                 level = StartInvData(
-                    capex = FixedProfile(500),
-                    max_inst = FixedProfile(600),
-                    inv_mode = FixedInvestment(),
-                    life_mode = UnlimitedLife(),
-                    initial = 0,
+                    FixedProfile(500),
+                    FixedProfile(600),
+                    0,
+                    FixedInvestment(),
+                    UnlimitedLife(),
                 )
             ),
         ]
@@ -428,18 +428,18 @@ end
         inv_data = [
             StorageInvData(
                 charge = StartInvData(
-                    capex = FixedProfile(20),
-                    max_inst = FixedProfile(30),
-                    initial = 0,
-                    inv_mode = BinaryInvestment(),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(20),
+                    FixedProfile(30),
+                    0,
+                    BinaryInvestment(),
+                    UnlimitedLife(),
                 ),
                 level = StartInvData(
-                    capex = FixedProfile(500),
-                    max_inst = FixedProfile(600),
-                    initial = 0,
-                    inv_mode = BinaryInvestment(),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(500),
+                    FixedProfile(600),
+                    0,
+                    BinaryInvestment(),
+                    UnlimitedLife(),
                 )
             ),
         ]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -142,16 +142,14 @@ function small_graph_stor(;
                 charge = NoStartInvData(
                     capex = FixedProfile(20),
                     max_inst = FixedProfile(30),
-                    max_add = FixedProfile(30),
-                    min_add = FixedProfile(rate_min_add),
-                    inv_mode = ContinuousInvestment(),
+                    inv_mode = ContinuousInvestment(FixedProfile(30), FixedProfile(rate_min_add)),
+                    life_mode = UnlimitedLife(),
                 ),
                 level = NoStartInvData(
                     capex = FixedProfile(500),
                     max_inst = FixedProfile(600),
-                    max_add = FixedProfile(600),
-                    min_add = FixedProfile(stor_min_add),
-                    inv_mode = ContinuousInvestment(),
+                    inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(stor_min_add)),
+                    life_mode = UnlimitedLife(),
                 )
             )
         ]
@@ -376,16 +374,14 @@ function network_graph()
                     charge = NoStartInvData(
                         capex = FixedProfile(0),
                         max_inst = FixedProfile(600),
-                        max_add = FixedProfile(600),
-                        min_add = FixedProfile(0),
-                        inv_mode = ContinuousInvestment(),
+                        inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(0)),
+                        life_mode = UnlimitedLife(),
                     ),
                     level = NoStartInvData(
                         capex = FixedProfile(500),
                         max_inst = FixedProfile(600),
-                        max_add = FixedProfile(600),
-                        min_add = FixedProfile(0),
-                        inv_mode = ContinuousInvestment(),
+                        inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(0)),
+                        life_mode = UnlimitedLife(),
                     )
                 ),
             ],
@@ -420,16 +416,14 @@ function network_graph()
                     charge = NoStartInvData(
                         capex = FixedProfile(0),
                         max_inst = FixedProfile(30),
-                        max_add = FixedProfile(3),
-                        min_add = FixedProfile(3),
-                        inv_mode = ContinuousInvestment(),
+                        inv_mode = ContinuousInvestment(FixedProfile(3), FixedProfile(3)),
+                        life_mode = UnlimitedLife(),
                     ),
                     level = NoStartInvData(
                         capex = FixedProfile(0),
                         max_inst = FixedProfile(50),
-                        max_add = FixedProfile(5),
-                        min_add = FixedProfile(5),
-                        inv_mode = ContinuousInvestment(),
+                        inv_mode = ContinuousInvestment(FixedProfile(5), FixedProfile(5)),
+                        life_mode = UnlimitedLife(),
                     )
                 ),
             ],

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -140,16 +140,16 @@ function small_graph_stor(;
         inv_data = [
             StorageInvData(
                 charge = NoStartInvData(
-                    capex = FixedProfile(20),
-                    max_inst = FixedProfile(30),
-                    inv_mode = ContinuousInvestment(FixedProfile(30), FixedProfile(rate_min_add)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(20),
+                    FixedProfile(30),
+                    ContinuousInvestment(FixedProfile(rate_min_add), FixedProfile(30)),
+                    UnlimitedLife(),
                 ),
                 level = NoStartInvData(
-                    capex = FixedProfile(500),
-                    max_inst = FixedProfile(600),
-                    inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(stor_min_add)),
-                    life_mode = UnlimitedLife(),
+                    FixedProfile(500),
+                    FixedProfile(600),
+                    ContinuousInvestment(FixedProfile(stor_min_add), FixedProfile(600)),
+                    UnlimitedLife(),
                 )
             )
         ]
@@ -372,16 +372,16 @@ function network_graph()
             [
                 StorageInvData(
                     charge = NoStartInvData(
-                        capex = FixedProfile(0),
-                        max_inst = FixedProfile(600),
-                        inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(0)),
-                        life_mode = UnlimitedLife(),
+                        FixedProfile(0),
+                        FixedProfile(600),
+                        ContinuousInvestment(FixedProfile(0), FixedProfile(600)),
+                        UnlimitedLife(),
                     ),
                     level = NoStartInvData(
-                        capex = FixedProfile(500),
-                        max_inst = FixedProfile(600),
-                        inv_mode = ContinuousInvestment(FixedProfile(600), FixedProfile(0)),
-                        life_mode = UnlimitedLife(),
+                        FixedProfile(500),
+                        FixedProfile(600),
+                        ContinuousInvestment(FixedProfile(0), FixedProfile(600)),
+                        UnlimitedLife(),
                     )
                 ),
             ],
@@ -414,16 +414,16 @@ function network_graph()
             [
                 StorageInvData(
                     charge = NoStartInvData(
-                        capex = FixedProfile(0),
-                        max_inst = FixedProfile(30),
-                        inv_mode = ContinuousInvestment(FixedProfile(3), FixedProfile(3)),
-                        life_mode = UnlimitedLife(),
+                        FixedProfile(0),
+                        FixedProfile(30),
+                        ContinuousInvestment(FixedProfile(3), FixedProfile(3)),
+                        UnlimitedLife(),
                     ),
                     level = NoStartInvData(
-                        capex = FixedProfile(0),
-                        max_inst = FixedProfile(50),
-                        inv_mode = ContinuousInvestment(FixedProfile(5), FixedProfile(5)),
-                        life_mode = UnlimitedLife(),
+                        FixedProfile(0),
+                        FixedProfile(50),
+                        ContinuousInvestment(FixedProfile(5), FixedProfile(5)),
+                        UnlimitedLife(),
                     )
                 ),
             ],


### PR DESCRIPTION
In this PR, I rewrote how parameters are handled with the different `Investment` and `LifetimeMode`s. The aim is to move the required parameters to the individual composite types to avoid having to use `@kwargs` for investment data.