### PR TITLE
Deactivated tests for registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
           - version: '1.9'  # 1.9
             os: ubuntu-latest
             arch: x86
-          - version: 'nightly'
-            os: ubuntu-latest
-            arch: x64
+          # - version: 'nightly'
+          #   os: ubuntu-latest
+          #   arch: x64
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Unversioned
+## Version 0.7.0 (2024-08-20)
 
 ### Making `EnergyModelsInvestments` independent of `EnergyModelsBase`
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,32 +3,32 @@ using JuMP
 using Pkg
 using Test
 
-using EnergyModelsBase
-using EnergyModelsInvestments
-using TimeStruct
+# using EnergyModelsBase
+# using EnergyModelsInvestments
+# using TimeStruct
 
-const EMB = EnergyModelsBase
-const EMI = EnergyModelsInvestments
-const TS = TimeStruct
+# const EMB = EnergyModelsBase
+# const EMI = EnergyModelsInvestments
+# const TS = TimeStruct
 
-include("utils.jl")
+# include("utils.jl")
 
-@testset "Investments" begin
-    redirect_stdio(stdout=devnull) do
-        @testset "Investments | model" begin
-            include("test_model.jl")
-        end
+# @testset "Investments" begin
+#     redirect_stdio(stdout=devnull) do
+#         @testset "Investments | model" begin
+#             include("test_model.jl")
+#         end
 
-        @testset "Investments | lifetime" begin
-            include("test_lifetime.jl")
-        end
+#         @testset "Investments | lifetime" begin
+#             include("test_lifetime.jl")
+#         end
 
-        @testset "Investments | checks" begin
-            include("test_checks.jl")
-        end
+#         @testset "Investments | checks" begin
+#             include("test_checks.jl")
+#         end
 
-        @testset "Investments | examples" begin
-            include("test_examples.jl")
-        end
-    end
-end
+#         @testset "Investments | examples" begin
+#             include("test_examples.jl")
+#         end
+#     end
+# end


### PR DESCRIPTION
Based on the discussed approach for solving the hen and egg problem for EMB, we decided to deactivate the tests of EMI while registering. This PR corresponds hence to satisfying all bullet points in the last comment of #28 .