### PR TITLE
Activated tests after registration of `EnergyModelsBase` v0.8

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,32 +3,32 @@ using JuMP
 using Pkg
 using Test
 
-# using EnergyModelsBase
-# using EnergyModelsInvestments
-# using TimeStruct
+using EnergyModelsBase
+using EnergyModelsInvestments
+using TimeStruct
 
-# const EMB = EnergyModelsBase
-# const EMI = EnergyModelsInvestments
-# const TS = TimeStruct
+const EMB = EnergyModelsBase
+const EMI = EnergyModelsInvestments
+const TS = TimeStruct
 
-# include("utils.jl")
+include("utils.jl")
 
-# @testset "Investments" begin
-#     redirect_stdio(stdout=devnull) do
-#         @testset "Investments | model" begin
-#             include("test_model.jl")
-#         end
+@testset "Investments" begin
+    redirect_stdio(stdout=devnull) do
+        @testset "Investments | model" begin
+            include("test_model.jl")
+        end
 
-#         @testset "Investments | lifetime" begin
-#             include("test_lifetime.jl")
-#         end
+        @testset "Investments | lifetime" begin
+            include("test_lifetime.jl")
+        end
 
-#         @testset "Investments | checks" begin
-#             include("test_checks.jl")
-#         end
+        @testset "Investments | checks" begin
+            include("test_checks.jl")
+        end
 
-#         @testset "Investments | examples" begin
-#             include("test_examples.jl")
-#         end
-#     end
-# end
+        @testset "Investments | examples" begin
+            include("test_examples.jl")
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,21 +14,19 @@ const TS = TimeStruct
 include("utils.jl")
 
 @testset "Investments" begin
-    redirect_stdio(stdout=devnull) do
-        @testset "Investments | model" begin
-            include("test_model.jl")
-        end
+    @testset "Investments | model" begin
+        include("test_model.jl")
+    end
 
-        @testset "Investments | lifetime" begin
-            include("test_lifetime.jl")
-        end
+    @testset "Investments | lifetime" begin
+        include("test_lifetime.jl")
+    end
 
-        @testset "Investments | checks" begin
-            include("test_checks.jl")
-        end
+    @testset "Investments | checks" begin
+        include("test_checks.jl")
+    end
 
-        @testset "Investments | examples" begin
-            include("test_examples.jl")
-        end
+    @testset "Investments | examples" begin
+        include("test_examples.jl")
     end
 end

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -3,8 +3,7 @@ ENV["EMX_TEST"] = true # Set flag for example scripts to check if they are run a
 @testset "Run examples" begin
     exdir = joinpath(@__DIR__, "..", "examples")
     files = filter(endswith(".jl"), readdir(exdir))
-    filter!(!startswith("geo"), files) # Skip geo temporarily
-    for file in files
+    for file ∈ files
         @testset "Example $file" begin
             redirect_stdio(stdout=devnull, stderr=devnull) do
                 include(joinpath(exdir, file))


### PR DESCRIPTION
PR #31 deactivated the tests so that we could register a version with running tests (although nothing was tested). These are reactivated in this PR. In addition, I changed the suppressions to focus only on the examples to still get the error messages of the tests, if they are failing.