### PR TITLE
FIxed a bug in RollingLife

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
           - version: '1.9'  # 1.9 
             os: ubuntu-latest
             arch: x64
-          - version: '1.9'  # 1.9
-            os: ubuntu-latest
-            arch: x86
+          # - version: '1.9'  # 1.9
+          #   os: ubuntu-latest
+          #   arch: x86
           # - version: 'nightly'
           #   os: ubuntu-latest
           #   arch: x64

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## Version 0.7.1 (2024-08-26)
+
+* Bugfix in `RollingLife` in a situation, in which the duration of a strategic period equals the lifetime of the technology.
+  A test was added to avoid this type of problem in the future
+
 ## Version 0.7.0 (2024-08-20)
 
 ### Making `EnergyModelsInvestments` independent of `EnergyModelsBase`

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsInvestments"
 uuid = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Dimitri Pinel <Dimitri.Pinel@sintef.no>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -94,7 +94,7 @@ function generate_example_data_network()
             FixedProfile(80),           # Capacity in MW
             FixedProfile(30),           # Variable OPEX in EUR/MWh
             FixedProfile(100),          # Fixed OPEX in EUR/year
-            Dict(NG => 1),              # Output from the Node, in this gase, NG
+            Dict(NG => 1),              # Output from the Node, in this case, NG
             Data[],                         # Potential additional data, no investment for the source
         ),
         RefSource(                      # Coal source
@@ -102,7 +102,7 @@ function generate_example_data_network()
             FixedProfile(100),          # Capacity in MW
             FixedProfile(9),            # Variable OPEX in EUR/MWh
             FixedProfile(100),          # Fixed OPEX in EUR/year
-            Dict(Coal => 1),            # Output from the Node, in this gase, coal
+            Dict(Coal => 1),            # Output from the Node, in this case, coal
             Data[],                         # Potential additional data, no investment for the source
         ),
         RefNetworkNode(                 # Natural gas power plant with CCS

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -95,7 +95,7 @@ function generate_example_data_network()
             FixedProfile(30),           # Variable OPEX in EUR/MWh
             FixedProfile(100),          # Fixed OPEX in EUR/year
             Dict(NG => 1),              # Output from the Node, in this case, NG
-            Data[],                         # Potential additional data, no investment for the source
+            Data[],                     # Potential additional data, no investment for the source
         ),
         RefSource(                      # Coal source
             "coal source",              # Node id
@@ -103,7 +103,7 @@ function generate_example_data_network()
             FixedProfile(9),            # Variable OPEX in EUR/MWh
             FixedProfile(100),          # Fixed OPEX in EUR/year
             Dict(Coal => 1),            # Output from the Node, in this case, coal
-            Data[],                         # Potential additional data, no investment for the source
+            Data[],                     # Potential additional data, no investment for the source
         ),
         RefNetworkNode(                 # Natural gas power plant with CCS
             "NG+CCS power plant",       # Node id

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -76,7 +76,7 @@ function generate_ss_example_data(lifemode = RollingLife; discount_rate = 0.05)
         FixedProfile(0),            # Capacity in MW
         FixedProfile(10),           # Variable OPEX in EUR/MW
         FixedProfile(5),            # Fixed OPEX in EUR/year
-        Dict(Power => 1),           # Output from the Node, in this gase, Power
+        Dict(Power => 1),           # Output from the Node, in this case, Power
         [investment_data_source],   # Additional data used for adding the investment data
     )
     sink = RefSink(

--- a/src/model.jl
+++ b/src/model.jl
@@ -267,7 +267,7 @@ function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rat
             # If lifetime is equal to sp duration we only need to invest once and there is no
             # rest value. The invested capacity is removed at the end of the strategic period
         elseif lifetime_val == duration_strat(t_inv)
-            @constraint(m, var_capex[t_inv] == capex_val)
+            @constraint(m, var_capex[t_inv] == capex_val[t_inv])
             @constraint(m, var_rem[t_inv] == var_add[t_inv])
 
             # If lifetime is longer than sp duration, the capacity can roll over to the next sp

--- a/test/test_lifetime.jl
+++ b/test/test_lifetime.jl
@@ -2,7 +2,7 @@ resulting_obj = Dict()
 @testset "Test Lifetime" begin
 
     lifetime = 15
-    for sp_dur ∈ [2, 4, 6, 15]#,10,15,20]
+    for sp_dur ∈ [2, 4, 6, 15]
         push!(resulting_obj, "$(sp_dur) years" => [])
         @testset "Modes - $(sp_dur) years" begin
             for life_mode ∈ [

--- a/test/test_lifetime.jl
+++ b/test/test_lifetime.jl
@@ -2,7 +2,7 @@ resulting_obj = Dict()
 @testset "Test Lifetime" begin
 
     lifetime = 15
-    for sp_dur ∈ [2, 4, 6]#,10,15,20]
+    for sp_dur ∈ [2, 4, 6, 15]#,10,15,20]
         push!(resulting_obj, "$(sp_dur) years" => [])
         @testset "Modes - $(sp_dur) years" begin
             for life_mode ∈ [


### PR DESCRIPTION
When the `RollingLife` lifetime was equal to the duration of a strategic period, we received an error as I forgot to include the index `[t_inv]`. This is now fixed in this PR.

In addition, this PR includes typo corrections.