### PR TITLE
Improvement of docstrings and internal library

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -104,7 +104,7 @@ In addition this version includes:
 
 ### Bugfix
 
-* Added strategic period duration multiplication for emissions prices.
+* Added investment period duration multiplication for emissions prices.
 
 ## Version 0.4.5 (2023-10-24)
 

--- a/docs/src/how-to/contribute.md
+++ b/docs/src/how-to/contribute.md
@@ -27,7 +27,7 @@ When filing a bug report, please follow the following guidelines:
 
     In order to improve the code, we welcome any reports of potential method ambiguities to help us improving the structure of the framework.
 
-## [Feature requests](@id how_to-feat_req)
+## [Feature requests](@id how_to-con-feat_req)
 
 `EnergyModelsInvestments` includes several `Investment` options and `LifetimeMode`s.
 However, not all potential options are included.

--- a/docs/src/how-to/update-models.md
+++ b/docs/src/how-to/update-models.md
@@ -242,7 +242,7 @@ investment_data_source = SingleInvData(
     FixedProfile(0),                # max installed capacity [MW]
     FixedInvestments(StrategicProfile([10, 15])),
     # Line above: Investment mode with the following arguments:
-    # New capacity in the strategic period, if invested in [MW]
+    # New capacity in the investment period, if invested in [MW]
     RollingLife(FixedProfile(15)),  # Lifetime mode
 )
 ```

--- a/docs/src/how-to/use-emi.md
+++ b/docs/src/how-to/use-emi.md
@@ -71,7 +71,7 @@ Hence, it is best to declare all variables as, *e.g.* using the prefix `:cap`:
 ```julia
 𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-# Add investment variables for reference nodes for each strategic period:
+# Add investment variables for reference nodes for each investment period:
 @variable(m, cap_inst[𝒩ᴵⁿᵛ] >= 0)
 @variable(m, cap_capex[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] >= 0)
 @variable(m, cap_current[𝒩ᴵⁿᵛ, 𝒯ᴵⁿᵛ] >= 0)
@@ -129,7 +129,7 @@ Note that we included in this example a method for `investment_data()` as outlin
 
 `EnergyModelsInvestments` does not change the objective function.
 This would require detailed knowledge regarding the individual contributing factors.
-Hence, we decided that it is beneficial to instead calculate the capital expense contributions in each strategic period.
+Hence, we decided that it is beneficial to instead calculate the capital expense contributions in each investment period.
 As a consequence, when using `EnergyModelsInvestments`, you have to include the variable ``\texttt{cap\_capex}`` (if you used `prefix = :cap`) for all elements with investments to your objective function.
 
 An illustrative example is given in the function `EMB.objective(m, 𝒩, 𝒯, 𝒫, modeltype::AbstractInvestmentModel)` compared to the function `objective(m, 𝒩, 𝒯, 𝒫, modeltype::EnergyModel)` in `EnergyModelsBase`.

--- a/docs/src/library/internals.md
+++ b/docs/src/library/internals.md
@@ -6,18 +6,44 @@
 Pages = ["internals.md"]
 ```
 
-## Types
+## Core functions
 
-```@autodocs
-Modules = [EMI]
-Public = false
-Order = [:type]
+```@docs
+EnergyModelsInvestments.add_investment_constraints
+EnergyModelsInvestments.set_capacity_installation
+EnergyModelsInvestments.set_capacity_cost
+EnergyModelsInvestments.set_capex_value
 ```
 
-## Methods
+## Variable extraction functions
 
-```@autodocs
-Modules = [EMI]
-Public = false
-Order = [:function]
+```@docs
+EnergyModelsInvestments.get_var_capex
+EnergyModelsInvestments.get_var_inst
+EnergyModelsInvestments.get_var_current
+EnergyModelsInvestments.get_var_rem
+EnergyModelsInvestments.get_var_add
+EnergyModelsInvestments.get_var_invest_b
+EnergyModelsInvestments.get_var_remove_b
+```
+
+## Functions for extracting fields
+
+```@docs
+EnergyModelsInvestments.capex
+EnergyModelsInvestments.max_installed
+EnergyModelsInvestments.min_add
+EnergyModelsInvestments.max_add
+EnergyModelsInvestments.capex_offset
+EnergyModelsInvestments.invest_capacity
+EnergyModelsInvestments.increment
+EnergyModelsInvestments.lifetime_mode
+EnergyModelsInvestments.lifetime
+```
+
+## Utility functions
+
+```@docs
+EnergyModelsInvestments.set_capex_discounter
+EnergyModelsInvestments.start_cap
 ```

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -32,7 +32,7 @@ The following fields have to be added for all provided types:
 
 The type `StartInvData` allows in addition for providing the initial capacity in the first year through:
 
-- `initial::Real`: Starting capacity of the technology in the first strategic period. The starting capacity is only valid for the first strategic period. This capacity will remain present in the simulation horizon, except if retiring is desired by the model. It is not possible to provide a reducing capacity over time for the initial capacity.
+- `initial::Real`: Starting capacity of the technology in the first investment period. The starting capacity is only valid for the first investment period. This capacity will remain present in the simulation horizon, except if retiring is desired by the model. It is not possible to provide a reducing capacity over time for the initial capacity.
 
 while it utilizes the capacity of the technology if the value is not provided through the function [`EMI.start_cap`](@ref).
 
@@ -79,12 +79,12 @@ The investment mode determines how the model can invest and which constraints ar
 Investment modes are including the required fields.
 These fields are given below with a detailed description in the individual subsections.
 
-- `max_add::TimeProfile`: The maximum added capacity in a strategic period.
-  The maximum added capacity is providing the limit on how fast we can expend a given technology in a strategic period.
+- `max_add::TimeProfile`: The maximum added capacity in a investment period.
+  The maximum added capacity is providing the limit on how fast we can expend a given technology in a investment period.
   In general, this value is dependent on the potential construction time and how fast it is possible to build a technology.
   It is introduced for `ContinuousInvestment` and `SemiContiInvestment` modes.
-- `min_add::TimeProfile`: The minimum added capacity in a strategic period.
-  The minimum added capacity is providing the lower limit on investments in a strategic period.
+- `min_add::TimeProfile`: The minimum added capacity in a investment period.
+  The minimum added capacity is providing the lower limit on investments in a investment period.
   Its meaning changes, dependent on the chosen investment mode.
   It is introduced for `ContinuousInvestment` and `SemiContiInvestment` modes.
 - `capex_offset::TimeProfile`: CAPEX offset for the [`SemiContinuousOffsetInvestment`](@ref) mode.
@@ -106,7 +106,7 @@ Investment
 
 `ContinuousInvestment` is the default investment option for all investments, if no alternative is chosen.
 Continuous investments implies that you can invest in any capacity specified between `min_add` and `max_add`.
-This implies as well that, if `min_add` is specified, it is necessary to invest in every strategic period in at least this capacity.
+This implies as well that, if `min_add` is specified, it is necessary to invest in every investment period in at least this capacity.
 This approach is the standard approach in large energy system models as it avoids binary variables.
 However, it may lead to nonsensical solutions, *e.g.*, investments into a 10~MW nuclear power plant.
 
@@ -119,7 +119,7 @@ ContinuousInvestment
 
 ### `BinaryInvestment`
 
-[`BinaryInvestment`](@ref) implies that one can choose to invest to achieve the specified capacity in the given strategic period, or not.
+[`BinaryInvestment`](@ref) implies that one can choose to invest to achieve the specified capacity in the given investment period, or not.
 The capacity of the investment cannot be adjusted by the optimization.
 
 !!! warning
@@ -134,7 +134,7 @@ BinaryInvestment
 
 `DiscreteInvestment` allow for only a discrete increase in the capacity.
 This increase is specified through the field `increment`.
-Hence, it can be also dependent on the strategic period.
+Hence, it can be also dependent on the investment period.
 
 `DiscreteInvestment` can for example be used to represent investment in modular technologies that can be scaled by adding several modules together.
 In addition, it is beneficial to include for technologies that experience significant economy of scale.
@@ -243,8 +243,8 @@ LifetimeMode
 ### `UnlimitedLife`
 
 This `LifetimeMode` is used when the lifetime of a `Node` is not limited.
-No reinvestment is considered by the optimization and there is also ne salvage value (or rest value) at the end of the last strategic period.
-Hence, the costs are the same, independent of if the investments in the `Node` are happening in the first strategic period (and the technology is used for, *e.g*, 25 years) or the last strategic period (with a usage of, *e.g.*, 5 years) when excluding discounting effects.
+No reinvestment is considered by the optimization and there is also ne salvage value (or rest value) at the end of the last investment period.
+Hence, the costs are the same, independent of if the investments in the `Node` are happening in the first investment period (and the technology is used for, *e.g*, 25 years) or the last investment period (with a usage of, *e.g.*, 5 years) when excluding discounting effects.
 
 `UnlimitedLife` is the default lifetime mode, if no other mode is specified.
 
@@ -256,7 +256,7 @@ UnlimitedLife
 
 `StudyLife` includes the technology for the full investigated horizon.
 If the `Lifetime` is shorter than the remaining horizon, reinvestments are considered.
-These reinvestments are included in the costs of the investment strategic period, but discounted to their actual value.
+These reinvestments are included in the costs of the investment investment period, but discounted to their actual value.
 
 As an example, consider investments with a lifetime of 20 years in 2030, while the study horizon ends in 2055.
 In this situation, reinvestments are required in 2050 to allow for operation in the last 5 years.
@@ -268,9 +268,9 @@ StudyLife
 
 ### `PeriodLife`
 
-`PeriodLife` is used to define that the investment is only lasting for the strategic period in which it happens.
+`PeriodLife` is used to define that the investment is only lasting for the investment period in which it happens.
 Additional year of lifetime are counted as a rest value.
-Reinvestment inside the strategic periods are also considered in case the lifetime is shorter than the length of the strategic period.
+Reinvestment inside the strategic periods are also considered in case the lifetime is shorter than the length of the investment period.
 
 ```@docs
 PeriodLife
@@ -278,12 +278,12 @@ PeriodLife
 
 ### `RollingLife`
 
-`RollingLife` corresponds to the classical roll-over of investments from one strategic period to the next until the end of life is reached.
+`RollingLife` corresponds to the classical roll-over of investments from one investment period to the next until the end of life is reached.
 In general, three different cases can be differentiated:
 
-1. The lifetime is shorter than the duration of the strategic period. In this situation, a [`PeriodLife`](@ref) is assumed.
-2. The lifetime equals the duration of the strategic period. In this situation, the capacity is retired at the end of the strategic period
-3. The lifetime is longer than the duration of the strategic period. This leaves however a problem if the lifetime does fall in-between two strategic periods, as it would be the case for a lifetime of, *e.g.*, 8 years and two strategic periods of, *e.g*, 5 years. In this case, the technology would only be available for the first 3 years of the second strategic period leaving the question on how to handle this situation. `EnergyModelsInvestments` retires the technology at the last full strategic period and calculates the remaining value for the technology.
+1. The lifetime is shorter than the duration of the investment period. In this situation, a [`PeriodLife`](@ref) is assumed.
+2. The lifetime equals the duration of the investment period. In this situation, the capacity is retired at the end of the investment period
+3. The lifetime is longer than the duration of the investment period. This leaves however a problem if the lifetime does fall in-between two strategic periods, as it would be the case for a lifetime of, *e.g.*, 8 years and two strategic periods of, *e.g*, 5 years. In this case, the technology would only be available for the first 3 years of the second investment period leaving the question on how to handle this situation. `EnergyModelsInvestments` retires the technology at the last full investment period and calculates the remaining value for the technology.
 
 ```@docs
 RollingLife

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -79,12 +79,12 @@ The investment mode determines how the model can invest and which constraints ar
 Investment modes are including the required fields.
 These fields are given below with a detailed description in the individual subsections.
 
-- `max_add::TimeProfile`: The maximum added capacity in a investment period.
+- `max_add::TimeProfile`: The maximum added capacity in an investment period.
   The maximum added capacity is providing the limit on how fast we can expend a given technology in a investment period.
   In general, this value is dependent on the potential construction time and how fast it is possible to build a technology.
   It is introduced for `ContinuousInvestment` and `SemiContiInvestment` modes.
-- `min_add::TimeProfile`: The minimum added capacity in a investment period.
-  The minimum added capacity is providing the lower limit on investments in a investment period.
+- `min_add::TimeProfile`: The minimum added capacity in an investment period.
+  The minimum added capacity is providing the lower limit on investments in an investment period.
   Its meaning changes, dependent on the chosen investment mode.
   It is introduced for `ContinuousInvestment` and `SemiContiInvestment` modes.
 - `capex_offset::TimeProfile`: CAPEX offset for the [`SemiContinuousOffsetInvestment`](@ref) mode.
@@ -243,7 +243,7 @@ LifetimeMode
 ### `UnlimitedLife`
 
 This `LifetimeMode` is used when the lifetime of a `Node` is not limited.
-No reinvestment is considered by the optimization and there is also ne salvage value (or rest value) at the end of the last investment period.
+No reinvestment is considered by the optimization and there is also no salvage value (or rest value) at the end of the last investment period.
 Hence, the costs are the same, independent of if the investments in the `Node` are happening in the first investment period (and the technology is used for, *e.g*, 25 years) or the last investment period (with a usage of, *e.g.*, 5 years) when excluding discounting effects.
 
 `UnlimitedLife` is the default lifetime mode, if no other mode is specified.

--- a/docs/src/manual/optimization-variables.md
+++ b/docs/src/manual/optimization-variables.md
@@ -26,7 +26,7 @@ The total CAPEX takes into account the invested capacity to calculate the total 
 The variable is extracted using the functions [`EMI.get_var_capex(m, prefix::Symbol)`](@ref) (for all variables) and [`EMI.get_var_capex(m, prefix::Symbol, element)`](@ref) (for only the variable from a given element instance) in which `m` corresponds to the JuMP model, and `prefix` to a prefix used in variable declaratio.
 
 !!! tip "Units of cost variables"
-    Cost variables provide the absolute costs within a investment period ``t_\texttt{inv}``.
+    Cost variables provide the absolute costs within an investment period ``t_\texttt{inv}``.
     An example unit would be € or $.
 
 ## [Capacity variables](@id man-opt_var-cap)
@@ -45,16 +45,16 @@ They are extracted using the functions functions [`EMI.get_var_inst(m, prefix::S
     The variable ``\texttt{cap\_inst}`` is slightly redundant in this design.
     It is indexed over operational periods ``t`` to allow for variations in the demand on an operational level within nodes without investments.
     This could have been also solved by using a profile, but it was decided to keep the current design.
-    The introduction of a new variable through ``\texttt{cap\_current}`` for the capacity at a investment period simplifies the indexing.
+    The introduction of a new variable through ``\texttt{cap\_current}`` for the capacity at an investment period simplifies the indexing.
 
     If you do not have nodes without investments, you still have to create the variable.
     In this case, we suggest to not use this variable at all and link the capacity usage directly to ``\texttt{cap\_current}``
 
-In addition, we introduce variables for investments in a investment period as:
+In addition, we introduce variables for investments in an investment period as:
 
 - ``\texttt{cap\_add}[n_\texttt{inv}, t_\texttt{inv}]``: Added capacity of `Node` ``n_\texttt{inv}`` with investments in the beginning of investment period ``t_\texttt{inv}``.
 
-The investments are available at the beginning of a investment period.
+The investments are available at the beginning of an investment period.
 They are extracted using the functions functions [`EMI.get_var_add(m, prefix::Symbol)`](@ref) and [`EMI.get_var_add(m, prefix::Symbol, element)`](@ref).
 
 The model can also choose to retire technologies at the end of each investment period through removal variables given as:

--- a/docs/src/manual/optimization-variables.md
+++ b/docs/src/manual/optimization-variables.md
@@ -8,7 +8,7 @@ The individual variables can be differentiated in *[Cost variables](@ref man-opt
 ## [General structure of variables](@id man-opt_var-gen)
 
 As an example, consider the capex variables.
-The capex variables with a prefix `:cap` are given by ``\texttt{cap\_capex}[n_\texttt{inv}, t_\texttt{inv}]`` for `Node` ``n_\texttt{inv}`` with investments in strategic period ``t_\texttt{inv}``.
+The capex variables with a prefix `:cap` are given by ``\texttt{cap\_capex}[n_\texttt{inv}, t_\texttt{inv}]`` for `Node` ``n_\texttt{inv}`` with investments in investment period ``t_\texttt{inv}``.
 They are extracted using the functions functions [`EMI.get_var_capex(m, prefix::Symbol)`](@ref) and [`EMI.get_var_capex(m, prefix::Symbol, element)`](@ref) in which `m` corresponds to the JuMP model, prefix to a prefix used in variable declaration (in this case `:cap`) and element to an instance of the element (in the previous example given as ``n_\texttt{inv}``).
 
 They are **not** declared within `EnergyModelsInvestments`, but have to be declared within the model using `EnergyModelsInvestments`.
@@ -16,17 +16,17 @@ This is illustrated in the `EMIExt` of `EnergyModelsBase`.
 
 ## [Cost variables](@id man-opt_var-cost)
 
-`EnergyModelsInvestments` requires the introduction of variables that help extracting the cost of investments in an element at each strategic period.
+`EnergyModelsInvestments` requires the introduction of variables that help extracting the cost of investments in an element at each investment period.
 One example is given through `EnergyModelsBase`:
 
-- ``\texttt{cap\_capex}[n_\texttt{inv}, t_\texttt{inv}]``: Undiscounted total CAPEX of `Node` ``n_\texttt{inv}`` with investments in strategic period ``t_\texttt{inv}``.
+- ``\texttt{cap\_capex}[n_\texttt{inv}, t_\texttt{inv}]``: Undiscounted total CAPEX of `Node` ``n_\texttt{inv}`` with investments in investment period ``t_\texttt{inv}``.
 
 The total CAPEX takes into account the invested capacity to calculate the total costs as well as the end of horizon value of the individual technologies including discounting.
 
 The variable is extracted using the functions [`EMI.get_var_capex(m, prefix::Symbol)`](@ref) (for all variables) and [`EMI.get_var_capex(m, prefix::Symbol, element)`](@ref) (for only the variable from a given element instance) in which `m` corresponds to the JuMP model, and `prefix` to a prefix used in variable declaratio.
 
 !!! tip "Units of cost variables"
-    Cost variables provide the absolute costs within a strategic period ``t_\texttt{inv}``.
+    Cost variables provide the absolute costs within a investment period ``t_\texttt{inv}``.
     An example unit would be € or $.
 
 ## [Capacity variables](@id man-opt_var-cap)
@@ -36,7 +36,7 @@ In general, we can differentiate in installed capacity variables and change of c
 The installed capacity variables are:
 
 - ``\texttt{cap\_inst}[n, t]``: Installed capacity of `Node` ``n`` with investments in operational period ``t`` and
-- ``\texttt{cap\_current}[n_\texttt{inv}, t_\texttt{inv}]``: Installed capacity of `Node` ``n_\texttt{inv}`` with investments in strategic period ``t_\texttt{inv}``.
+- ``\texttt{cap\_current}[n_\texttt{inv}, t_\texttt{inv}]``: Installed capacity of `Node` ``n_\texttt{inv}`` with investments in investment period ``t_\texttt{inv}``.
 
 The approach is similar to the *[Cost variables](@ref man-opt_var-cost)* as variables are created for each of the individual elements.
 They are extracted using the functions functions [`EMI.get_var_inst(m, prefix::Symbol)`](@ref) and [`EMI.get_var_inst(m, prefix::Symbol, element)`](@ref) as well as [`EMI.get_var_current(m, prefix::Symbol)`](@ref) and [`EMI.get_var_current(m, prefix::Symbol, element)`](@ref).
@@ -45,21 +45,21 @@ They are extracted using the functions functions [`EMI.get_var_inst(m, prefix::S
     The variable ``\texttt{cap\_inst}`` is slightly redundant in this design.
     It is indexed over operational periods ``t`` to allow for variations in the demand on an operational level within nodes without investments.
     This could have been also solved by using a profile, but it was decided to keep the current design.
-    The introduction of a new variable through ``\texttt{cap\_current}`` for the capacity at a strategic period simplifies the indexing.
+    The introduction of a new variable through ``\texttt{cap\_current}`` for the capacity at a investment period simplifies the indexing.
 
     If you do not have nodes without investments, you still have to create the variable.
     In this case, we suggest to not use this variable at all and link the capacity usage directly to ``\texttt{cap\_current}``
 
-In addition, we introduce variables for investments in a strategic period as:
+In addition, we introduce variables for investments in a investment period as:
 
-- ``\texttt{cap\_add}[n_\texttt{inv}, t_\texttt{inv}]``: Added capacity of `Node` ``n_\texttt{inv}`` with investments in the beginning of strategic period ``t_\texttt{inv}``.
+- ``\texttt{cap\_add}[n_\texttt{inv}, t_\texttt{inv}]``: Added capacity of `Node` ``n_\texttt{inv}`` with investments in the beginning of investment period ``t_\texttt{inv}``.
 
-The investments are available at the beginning of a strategic period.
+The investments are available at the beginning of a investment period.
 They are extracted using the functions functions [`EMI.get_var_add(m, prefix::Symbol)`](@ref) and [`EMI.get_var_add(m, prefix::Symbol, element)`](@ref).
 
-The model can also choose to retire technologies at the end of each strategic period through removal variables given as:
+The model can also choose to retire technologies at the end of each investment period through removal variables given as:
 
-- ``\texttt{cap\_rem}[n_\texttt{inv}, t_\texttt{inv}]``: Retired capacity of `Node` ``n_\texttt{inv}`` with investments at the end of strategic period ``t_\texttt{inv}``.
+- ``\texttt{cap\_rem}[n_\texttt{inv}, t_\texttt{inv}]``: Retired capacity of `Node` ``n_\texttt{inv}`` with investments at the end of investment period ``t_\texttt{inv}``.
 
 The retired capacity corresponds to removal of capacity, either due to the end of lifetime or due to lack of usage.
 Capacity removal has an impact on the objective function due to removal of the fixed OPEX.

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -41,12 +41,12 @@ function generate_example_data_network()
     op_number = 24  # There are in total 4 operational periods
     operational_periods = SimpleTimes(op_number, op_duration)
 
-    # The duration of operational periods per duration of 1 of a strategic period of 8760
+    # The duration of operational periods per duration of 1 of a investment period of 8760
     # implies that a duration of 1 of an operational period corresponds to an hour, while
-    # a duration of 1 of a strategic period corresponds to a year
+    # a duration of 1 of a investment period corresponds to a year
     op_per_strat = 8760
 
-    sp_duration = 5 # The duration of a strategic period is given as 5 years
+    sp_duration = 5 # The duration of a investment period is given as 5 years
 
     # Create the time structure It corresponds to simulating one day in a year over
     # 4 strategic periods

--- a/examples/network.jl
+++ b/examples/network.jl
@@ -41,12 +41,12 @@ function generate_example_data_network()
     op_number = 24  # There are in total 4 operational periods
     operational_periods = SimpleTimes(op_number, op_duration)
 
-    # The duration of operational periods per duration of 1 of a investment period of 8760
+    # The duration of operational periods per duration of 1 of an investment period of 8760
     # implies that a duration of 1 of an operational period corresponds to an hour, while
-    # a duration of 1 of a investment period corresponds to a year
+    # a duration of 1 of an investment period corresponds to a year
     op_per_strat = 8760
 
-    sp_duration = 5 # The duration of a investment period is given as 5 years
+    sp_duration = 5 # The duration of an investment period is given as 5 years
 
     # Create the time structure It corresponds to simulating one day in a year over
     # 4 strategic periods

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -39,12 +39,12 @@ function generate_ss_example_data(lifemode = RollingLife; discount_rate = 0.05)
     op_number = 4   # There are in total 4 operational periods
     operational_periods = SimpleTimes(op_number, op_duration)
 
-    # The duration of operational periods per duration of 1 of a strategic period of 8760
+    # The duration of operational periods per duration of 1 of a investment period of 8760
     # implies that a duration of 1 of an operational period corresponds to an hour, while
-    # a duration of 1 of a strategic period corresponds to a year
+    # a duration of 1 of a investment period corresponds to a year
     op_per_strat = 8760
 
-    sp_duration = 5 # The duration of a strategic period is given as 5 years
+    sp_duration = 5 # The duration of a investment period is given as 5 years
 
     # Creation of the time structure and global data
     T = TwoLevel(4, sp_duration, operational_periods; op_per_strat)
@@ -55,7 +55,7 @@ function generate_ss_example_data(lifemode = RollingLife; discount_rate = 0.05)
     model = InvestmentModel(em_limits, em_cost, CO2, discount_rate)
 
     # The lifetime of the technology is 15 years, requiring reinvestment in the
-    # 5th strategic period
+    # 5th investment period
     lifetime = FixedProfile(15)
 
     # Create the investment data for the source node

--- a/examples/sink_source.jl
+++ b/examples/sink_source.jl
@@ -39,12 +39,12 @@ function generate_ss_example_data(lifemode = RollingLife; discount_rate = 0.05)
     op_number = 4   # There are in total 4 operational periods
     operational_periods = SimpleTimes(op_number, op_duration)
 
-    # The duration of operational periods per duration of 1 of a investment period of 8760
+    # The duration of operational periods per duration of 1 of an investment period of 8760
     # implies that a duration of 1 of an operational period corresponds to an hour, while
-    # a duration of 1 of a investment period corresponds to a year
+    # a duration of 1 of an investment period corresponds to a year
     op_per_strat = 8760
 
-    sp_duration = 5 # The duration of a investment period is given as 5 years
+    sp_duration = 5 # The duration of an investment period is given as 5 years
 
     # Creation of the time structure and global data
     T = TwoLevel(4, sp_duration, operational_periods; op_per_strat)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -34,5 +34,5 @@ start_cap(element, t_inv, inv_data::StartInvData, cap) = inv_data.initial
 start_cap(element, t_inv, inv_data::NoStartInvData, cap) = error(
     "The function `start_cap` is not implemented for $(typeof(element)) and " *
     "`NoStartInvData`. If you want to use `NoStartInvData` as investment data, " *
-    "you have create this function for your type $(typeof(element)).",
+    "you have to create this function for your type $(typeof(element)).",
 )

--- a/src/model.jl
+++ b/src/model.jl
@@ -91,7 +91,7 @@ These constraints differ dependent on the chosen [`Investment`](@ref):
   variable. Furthermore, the variable `var_add` is bound through the functions
   [`min_add`](@ref) and [`max_add`](@ref) or 0.
 - **[`FixedInvestment`](@ref)** results in setting the variable `var_invest_b` as binary
-  variable. Furthermore, the variable `var_current` is fixed to a provided  value through
+  variable. Furthermore, the variable `var_current` is fixed to a provided value through
   the function [`invest_capacity`](@ref). This allows to incorporate the cost for the correct
   value of the objective function.
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -92,7 +92,7 @@ These constraints differ dependent on the chosen [`Investment`](@ref):
   [`min_add`](@ref) and [`max_add`](@ref) or 0.
 - **[`FixedInvestment`](@ref)** results in setting the variable `var_invest_b` as binary
   variable. Furthermore, the variable `var_current` is fixed to a provided  value through
-  the function [`invest_capacity`](@ref). Thi allows to incorporate the cost for the correct
+  the function [`invest_capacity`](@ref). This allows to incorporate the cost for the correct
   value of the objective function.
 
 !!! tip "Introducing new investment modes"

--- a/src/structures/investment_data.jl
+++ b/src/structures/investment_data.jl
@@ -85,115 +85,83 @@ are unlimited.
 lifetime_mode(inv_data::AbstractInvData) = inv_data.life_mode
 
 """
+    lifetime(inv_data::AbstractInvData)
     lifetime(inv_data::AbstractInvData, t_inv)
 
-Return the lifetime of the investment data `inv_data` in investment period `t_inv`.
+Return the lifetime of the investment data `inv_data` as `TimeProfile` or in investment
+period `t_inv`.
 """
+lifetime(inv_data::AbstractInvData) = lifetime(lifetime_mode(inv_data))
 lifetime(inv_data::AbstractInvData, t_inv) = lifetime(lifetime_mode(inv_data), t_inv)
 
 """
-    lifetime(inv_data::AbstractInvData)
-
-Return the lifetime of the investment data `inv_data` as `TimeProfile`.
-"""
-lifetime(inv_data::AbstractInvData) = lifetime(lifetime_mode(inv_data))
-
-"""
     capex(inv_data::AbstractInvData)
-
-Returns the CAPEX of the investment data `inv_data` as `TimeProfile`.
-"""
-capex(inv_data::AbstractInvData) = inv_data.capex
-"""
     capex(n::AbstractInvData, t_inv)
 
-Returns the CAPEX of the investment data `inv_data` in investment period `t_inv`.
+Returns the CAPEX of the investment data `inv_data` as `TimeProfile` or in investment
+period `t_inv`.
 """
+capex(inv_data::AbstractInvData) = inv_data.capex
 capex(inv_data::AbstractInvData, t_inv) = inv_data.capex[t_inv]
 
 """
     capex_offset(inv_data::AbstractInvData)
-
-Returns the offset of the CAPEX of the investment data `inv_data` as `TimeProfile`.
-"""
-capex_offset(inv_data::AbstractInvData) = capex_offset(investment_mode(inv_data))
-"""
     capex_offset(inv_data::AbstractInvData, t_inv)
 
-Returns the offset of the CAPEX of the investment data `inv_data` in investment period `t_inv`.
+Returns the offset of the CAPEX of the investment data `inv_data` as `TimeProfile` or in
+investment period `t_inv`.
 """
+capex_offset(inv_data::AbstractInvData) = capex_offset(investment_mode(inv_data))
 capex_offset(inv_data::AbstractInvData, t_inv) =
     capex_offset(investment_mode(inv_data), t_inv)
 
 """
     max_installed(inv_data::AbstractInvData)
-
-Returns the maximum allowed installed capacity the investment data `inv_data` as
-`TimeProfile`.
-"""
-max_installed(inv_data::AbstractInvData) = inv_data.max_inst
-"""
     max_installed(inv_data::AbstractInvData, t_inv)
 
-Returns the maximum allowed installed capacity of the investment data `inv_data` in
-investment period `t_inv`.
+Returns the maximum allowed installed capacity the investment data `inv_data` as
+`TimeProfile` or in investment period `t_inv`.
 """
+max_installed(inv_data::AbstractInvData) = inv_data.max_inst
 max_installed(inv_data::AbstractInvData, t_inv) = inv_data.max_inst[t_inv]
 
 """
     max_add(inv_data::AbstractInvData)
-
-Returns the maximum allowed added capacity of the investment data `inv_data` as
-`TimeProfile`.
-"""
-max_add(inv_data::AbstractInvData) = max_add(investment_mode(inv_data))
-"""
     max_add(inv_data::AbstractInvData, t_inv)
 
-Returns the maximum allowed added capacity of the investment data `inv_data` in investment
-period `t_inv`.
+Returns the maximum allowed added capacity of the investment data `inv_data` as
+`TimeProfile` or in investment period `t_inv`.
 """
+max_add(inv_data::AbstractInvData) = max_add(investment_mode(inv_data))
 max_add(inv_data::AbstractInvData, t_inv) = max_add(investment_mode(inv_data), t_inv)
 
 """
     min_add(inv_data::AbstractInvData)
-
-Returns the minimum allowed added capacity of the investment data `inv_data` as
-`TimeProfile`.
-"""
-min_add(inv_data::AbstractInvData) = min_add(investment_mode(inv_data))
-"""
     min_add(inv_data::AbstractInvData, t_inv)
 
-Returns the minimum allowed added capacity of the investment data `inv_data` in investment
-period `t_inv`.
+Returns the minimum allowed added capacity of the investment data `inv_data` as
+`TimeProfile` or in investment period `t_inv`.
 """
+min_add(inv_data::AbstractInvData) = min_add(investment_mode(inv_data))
 min_add(inv_data::AbstractInvData, t_inv) = min_add(investment_mode(inv_data), t_inv)
 
 """
     increment(inv_data::AbstractInvData)
-
-Returns the capacity increment of the investment data `inv_data` as `TimeProfile`.
-"""
-increment(inv_data::AbstractInvData) = increment(investment_mode(inv_data))
-"""
     increment(inv_data::AbstractInvData, t_inv)
 
-Returns the capacity increment of the investment data `inv_data` in investment period `t_inv`.
+Returns the capacity increment of the investment data `inv_data` as `TimeProfile` or in
+investment period `t_inv`.
 """
+increment(inv_data::AbstractInvData) = increment(investment_mode(inv_data))
 increment(inv_data::AbstractInvData, t_inv) = increment(investment_mode(inv_data), t_inv)
 
 """
     invest_capacity(inv_data::AbstractInvData)
-
-Returns the capacity investments of the investment data `inv_data` as `TimeProfile`.
-"""
-invest_capacity(inv_data::AbstractInvData) = invest_capacity(investment_mode(inv_data))
-"""
     invest_capacity(inv_data::AbstractInvData, t_inv)
 
-Returns the capacity profile for investments of the investment data `inv_data` in investment
-period `t_inv`.
+Returns the capacity investments of the investment data `inv_data` as `TimeProfile` or in
+investment period `t_inv`.
 """
+invest_capacity(inv_data::AbstractInvData) = invest_capacity(investment_mode(inv_data))
 invest_capacity(inv_data::AbstractInvData, t_inv) =
     invest_capacity(investment_mode(inv_data), t_inv)

--- a/src/structures/investment_data.jl
+++ b/src/structures/investment_data.jl
@@ -16,7 +16,7 @@ function [`start_cap(element, t_inv, inv_data::AbstractInvData, cap)`](@ref).
 # Fields
 - **`capex::TimeProfile`** is the capital costs for investing in a capacity. The value is
   relative to the added capacity.
-- **`max_inst::TimeProfile`** is the maximum installed capacity in a strategic period.
+- **`max_inst::TimeProfile`** is the maximum installed capacity in a investment period.
 - **`inv_mode::Investment`** is the chosen investment mode for the technology. The following
   investment modes are currently available: [`BinaryInvestment`](@ref),
   [`DiscreteInvestment`](@ref), [`ContinuousInvestment`](@ref), [`SemiContinuousInvestment`](@ref)

--- a/src/structures/investment_data.jl
+++ b/src/structures/investment_data.jl
@@ -16,7 +16,7 @@ function [`start_cap(element, t_inv, inv_data::AbstractInvData, cap)`](@ref).
 # Fields
 - **`capex::TimeProfile`** is the capital costs for investing in a capacity. The value is
   relative to the added capacity.
-- **`max_inst::TimeProfile`** is the maximum installed capacity in a investment period.
+- **`max_inst::TimeProfile`** is the maximum installed capacity in an investment period.
 - **`inv_mode::Investment`** is the chosen investment mode for the technology. The following
   investment modes are currently available: [`BinaryInvestment`](@ref),
   [`DiscreteInvestment`](@ref), [`ContinuousInvestment`](@ref), [`SemiContinuousInvestment`](@ref)

--- a/src/structures/investment_mode.jl
+++ b/src/structures/investment_mode.jl
@@ -125,70 +125,50 @@ end
 
 """
     capex_offset(inv_mode::SemiContinuousOffsetInvestment)
-
-Returns the offset of the CAPEX of the investment mode `inv_mode` as `TimeProfile`.
-"""
-capex_offset(inv_mode::SemiContinuousOffsetInvestment) = inv_mode.capex_offset
-"""
     capex_offset(inv_mode::SemiContinuousOffsetInvestment, t_inv)
 
-Returns the offset of the CAPEX of the investment mode `inv_mode` in investment period `t_inv`.
+Returns the offset of the CAPEX of the investment mode `inv_mode` as `TimeProfile` or in
+investment period `t_inv`.
 """
+capex_offset(inv_mode::SemiContinuousOffsetInvestment) = inv_mode.capex_offset
 capex_offset(inv_mode::SemiContinuousOffsetInvestment, t_inv) = inv_mode.capex_offset[t_inv]
 
 """
     min_add(inv_mode::Investment)
-
-Returns the minimum allowed added capacity of the investment mode `inv_mode` as
-`TimeProfile`.
-"""
-min_add(inv_mode::Investment) = inv_mode.min_add
-"""
     min_add(inv_mode::Investment, t_inv)
 
-Returns the minimum allowed added capacity of the investment mode `inv_mode` in investment
-period `t_inv`.
+Returns the minimum allowed added capacity of the investment mode `inv_mode` as
+`TimeProfile` or in investment period `t_inv`.
 """
+min_add(inv_mode::Investment) = inv_mode.min_add
 min_add(inv_mode::Investment, t_inv) = inv_mode.min_add[t_inv]
 
 """
     max_add(inv_mode::Investment)
-
-Returns the maximum allowed added capacity of the investment mode `inv_mode` as
-`TimeProfile`.
-"""
-max_add(inv_mode::Investment) = inv_mode.max_add
-"""
     max_add(inv_mode::Investment, t_inv)
 
-Returns the maximum allowed added capacity of the investment mode `inv_mode` investment
-period `t_inv`.
+Returns the maximum allowed added capacity of the investment mode `inv_mode` as
+`TimeProfile` or in investment period `t_inv`.
 """
+max_add(inv_mode::Investment) = inv_mode.max_add
 max_add(inv_mode::Investment, t_inv) = inv_mode.max_add[t_inv]
 
 """
     increment(inv_mode::Investment)
-
-Returns the capacity increment of the investment mode `inv_mode` as `TimeProfile`.
-"""
-increment(inv_mode::Investment) = inv_mode.increment
-"""
     increment(inv_mode::Investment, t_inv)
 
-Returns the capacity increment of the investment mode `inv_mode` in investment period `t_inv`.
+Returns the capacity increment of the investment mode `inv_mode` as `TimeProfile` or in
+investment period `t_inv`.
 """
+increment(inv_mode::Investment) = inv_mode.increment
 increment(inv_mode::Investment, t_inv) = inv_mode.increment[t_inv]
 
 """
     invest_capacity(inv_mode::Investment)
-
-Returns the capacity investments of the investment mode `inv_mode` as `TimeProfile`.
-"""
-invest_capacity(inv_mode::Investment) = inv_mode.cap
-"""
     invest_capacity(inv_mode::Investment, t_inv)
 
-Returns the capacity profile for investments of the investment mode `inv_mode` in investment
-period `t_inv`.
+Returns the capacity investments of the investment mode `inv_mode` as `TimeProfile` or in
+investment period `t_inv`.
 """
+invest_capacity(inv_mode::Investment) = inv_mode.cap
 invest_capacity(inv_mode::Investment, t_inv) = inv_mode.cap[t_inv]

--- a/src/structures/investment_mode.jl
+++ b/src/structures/investment_mode.jl
@@ -24,7 +24,7 @@ end
     BinaryInvestment <: Investment
 
 Binary investment in a given capacity with binary variables.
-The chosen capacity within a investment period is given by the field `cap`.
+The chosen capacity within an investment period is given by the field `cap`.
 
 Binary investments introduce one binary variable for each investment period.
 
@@ -57,10 +57,10 @@ end
 Continuous investment between a lower and upper bound.
 
 # Fields
-- **`min_add::TimeProfile`** is the minimum added capacity in a investment period. In the
+- **`min_add::TimeProfile`** is the minimum added capacity in an investment period. In the
   case of `ContinuousInvestment`, this implies that the model **must** invest at least
   in this capacity in each investment period.
-- **`max_add::TimeProfile`** is the maximum added capacity in a investment period.
+- **`max_add::TimeProfile`** is the maximum added capacity in an investment period.
 """
 struct ContinuousInvestment <: Investment
     min_add::TimeProfile
@@ -87,11 +87,11 @@ still linear dependent on the
 Semi-continuous investments introduce one binary variable for each investment period.
 
 # Fields
-- **`min_add::TimeProfile`** is the minimum added capacity in a investment period. In the
+- **`min_add::TimeProfile`** is the minimum added capacity in an investment period. In the
   case of `SemiContinuousInvestment`, this implies that the model **must** invest at least
   in this capacity in each investment period. in this capacity in each investment period where
   the model decides to invest. The model can also choose not too invest at all.
-- **`max_add::TimeProfile`** is the maximum added capacity in a investment period.
+- **`max_add::TimeProfile`** is the maximum added capacity in an investment period.
 """
 struct SemiContinuousInvestment <: SemiContiInvestment
     min_add::TimeProfile
@@ -110,12 +110,12 @@ user to use different slopes, and hence, account for economy of scales.
 Semi-continuous investments introduce one binary variable for each investment period.
 
 # Fields
-- **`max_add::TimeProfile`** is the maximum added capacity in a investment period.
-- **`min_add::TimeProfile`** is the minimum added capacity in a investment period. In the
+- **`max_add::TimeProfile`** is the maximum added capacity in an investment period.
+- **`min_add::TimeProfile`** is the minimum added capacity in an investment period. In the
   case of `SemiContinuousOffsetInvestment`, this implies that the model **must** invest at
   least in this capacity in each investment period. in this capacity in each investment period
   where the model decides to invest. The model can also choose not too invest at all.
-- **`capex_offset::TimeProfile`** is offset for the CAPEX in a investment period.
+- **`capex_offset::TimeProfile`** is offset for the CAPEX in an investment period.
 """
 struct SemiContinuousOffsetInvestment <: SemiContiInvestment
     min_add::TimeProfile

--- a/src/structures/investment_mode.jl
+++ b/src/structures/investment_mode.jl
@@ -24,9 +24,9 @@ end
     BinaryInvestment <: Investment
 
 Binary investment in a given capacity with binary variables.
-The chosen capacity within a strategic period is given by the field `cap`.
+The chosen capacity within a investment period is given by the field `cap`.
 
-Binary investments introduce one binary variable for each strategic period.
+Binary investments introduce one binary variable for each investment period.
 
 # Fields
 - **`cap::TimeProfile`** is the capacity used for the fixed investments.
@@ -42,7 +42,7 @@ Discrete investment with integer variables using an increment.
 The increment for the discrete investment can be different for the individual strategic
 periods.
 
-Discrete investments introduce one integer variable for each strategic period.
+Discrete investments introduce one integer variable for each investment period.
 
 # Fields
 - **`increment::TimeProfile`** is the used increment.
@@ -57,10 +57,10 @@ end
 Continuous investment between a lower and upper bound.
 
 # Fields
-- **`min_add::TimeProfile`** is the minimum added capacity in a strategic period. In the
+- **`min_add::TimeProfile`** is the minimum added capacity in a investment period. In the
   case of `ContinuousInvestment`, this implies that the model **must** invest at least
-  in this capacity in each strategic period.
-- **`max_add::TimeProfile`** is the maximum added capacity in a strategic period.
+  in this capacity in each investment period.
+- **`max_add::TimeProfile`** is the maximum added capacity in a investment period.
 """
 struct ContinuousInvestment <: Investment
     min_add::TimeProfile
@@ -73,7 +73,7 @@ end
 Supertype for semi-continuous investments, that is the added capacity is either zero or
 between a minimum and a maximum value.
 
-Semi-continuous investments introduce one binary variable for each strategic period.
+Semi-continuous investments introduce one binary variable for each investment period.
 """
 abstract type SemiContiInvestment <: Investment end
 
@@ -84,14 +84,14 @@ Semi-continuous investments, that is the added capacity is either zero or betwee
 and a maximum value. In this subtype, the cost is crossing the origin, that is the CAPEX is
 still linear dependent on the
 
-Semi-continuous investments introduce one binary variable for each strategic period.
+Semi-continuous investments introduce one binary variable for each investment period.
 
 # Fields
-- **`min_add::TimeProfile`** is the minimum added capacity in a strategic period. In the
+- **`min_add::TimeProfile`** is the minimum added capacity in a investment period. In the
   case of `SemiContinuousInvestment`, this implies that the model **must** invest at least
-  in this capacity in each strategic period. in this capacity in each strategic period where
+  in this capacity in each investment period. in this capacity in each investment period where
   the model decides to invest. The model can also choose not too invest at all.
-- **`max_add::TimeProfile`** is the maximum added capacity in a strategic period.
+- **`max_add::TimeProfile`** is the maximum added capacity in a investment period.
 """
 struct SemiContinuousInvestment <: SemiContiInvestment
     min_add::TimeProfile
@@ -107,15 +107,15 @@ is an offset (y- intercept) in the variable `capex_cap`, that is its value is la
 than 0 at an invested capacity of 0 given by the field `capex_offset`. This allows to the
 user to use different slopes, and hence, account for economy of scales.
 
-Semi-continuous investments introduce one binary variable for each strategic period.
+Semi-continuous investments introduce one binary variable for each investment period.
 
 # Fields
-- **`max_add::TimeProfile`** is the maximum added capacity in a strategic period.
-- **`min_add::TimeProfile`** is the minimum added capacity in a strategic period. In the
+- **`max_add::TimeProfile`** is the maximum added capacity in a investment period.
+- **`min_add::TimeProfile`** is the minimum added capacity in a investment period. In the
   case of `SemiContinuousOffsetInvestment`, this implies that the model **must** invest at
-  least in this capacity in each strategic period. in this capacity in each strategic period
+  least in this capacity in each investment period. in this capacity in each investment period
   where the model decides to invest. The model can also choose not too invest at all.
-- **`capex_offset::TimeProfile`** is offset for the CAPEX in a strategic period.
+- **`capex_offset::TimeProfile`** is offset for the CAPEX in a investment period.
 """
 struct SemiContinuousOffsetInvestment <: SemiContiInvestment
     min_add::TimeProfile

--- a/src/structures/lifetime_mode.jl
+++ b/src/structures/lifetime_mode.jl
@@ -28,7 +28,7 @@ end
 """
     PeriodLife <: LifetimeMode
 
-The investment is considered to last only for the strategic period. The excess
+The investment is considered to last only for the investment period. The excess
 lifetime is considered in the rest value. If the lifetime is lower than the length
 of the period, reinvestment is considered as well.
 
@@ -43,7 +43,7 @@ end
     RollingLife <: LifetimeMode
 
 The investment is rolling to the next strategic periods and it is retired at the
-end of its lifetime or the end of the previous strategic period if its lifetime
+end of its lifetime or the end of the previous investment period if its lifetime
 ends between two periods.
 
 # Fields

--- a/src/structures/lifetime_mode.jl
+++ b/src/structures/lifetime_mode.jl
@@ -55,13 +55,10 @@ end
 
 """
     lifetime(lifetime_mode::LifetimeMode)
-
-Return the lifetime of the lifetime mode `lifetime_mode` as `TimeProfile`.
-"""
-lifetime(lifetime_mode::LifetimeMode) = lifetime_mode.lifetime
-"""
     lifetime(lifetime_mode::LifetimeMode, t_inv)
 
-Return the lifetime of the lifetime mode `lifetime_mode` in investment period `t_inv`.
+Return the lifetime of the lifetime mode `lifetime_mode` as `TimeProfile` or in
+investment period `t_inv`.
 """
+lifetime(lifetime_mode::LifetimeMode) = lifetime_mode.lifetime
 lifetime(lifetime_mode::LifetimeMode, t_inv) = lifetime_mode.lifetime[t_inv]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,99 +1,71 @@
 """
     get_var_capex(m, prefix::Symbol)
-
-Extracts the CAPEX variable with a given `prefix` from the model.
-"""
-get_var_capex(m, prefix::Symbol) = m[Symbol(prefix, :_capex)]
-"""
     get_var_capex(m, prefix::Symbol, element)
 
-When the type `element` is used as conditional input, it extracts only the variable for
-the specified element.
+Extracts the CAPEX variable with a given `prefix` from the model or only the variable for
+    the specified `element`.
 """
+get_var_capex(m, prefix::Symbol) = m[Symbol(prefix, :_capex)]
 get_var_capex(m, prefix::Symbol, element) = m[Symbol(prefix, :_capex)][element, :]
 
 """
     get_var_inst(m, prefix::Symbol)
-
-Extracts the installed capacity variable with a given `prefix` from the model.
-"""
-get_var_inst(m, prefix::Symbol) = m[Symbol(prefix, :_inst)]
-"""
     get_var_inst(m, prefix::Symbol, element)
 
-When the type `element` is used as conditional input, it extracts only the variable for
-the specified element.
+Extracts the installed capacity variable with a given `prefix` from the model or only the
+variable for the specified `element`.
 """
+get_var_inst(m, prefix::Symbol) = m[Symbol(prefix, :_inst)]
 get_var_inst(m, prefix::Symbol, element) = m[Symbol(prefix, :_inst)][element, :]
 
 """
     get_var_current(m, prefix::Symbol)
-
-Extracts the current capacity variable with a given `prefix` from the model.
-"""
-get_var_current(m, prefix::Symbol) = m[Symbol(prefix, :_current)]
-"""
     get_var_current(m, prefix::Symbol, element)
 
-When the type `element` is used as conditional input, it extracts only the variable for
-the specified element.
+Extracts the current capacity variable with a given `prefix` from the model or only the
+variable for the specified `element`.
 """
+get_var_current(m, prefix::Symbol) = m[Symbol(prefix, :_current)]
 get_var_current(m, prefix::Symbol, element) = m[Symbol(prefix, :_current)][element, :]
 
 """
     get_var_add(m, prefix::Symbol)
-
-Extracts the investment capacity variable with a given `prefix` from the model.
-"""
-get_var_add(m, prefix::Symbol) = m[Symbol(prefix, :_add)]
-"""
     get_var_add(m, prefix::Symbol, element)
 
-When the type `element` is used as conditional input, it extracts only the variable for
-the specified element.
+Extracts the investment capacity variable with a given `prefix` from the model or only the
+variable for the specified `element`.
 """
+get_var_add(m, prefix::Symbol) = m[Symbol(prefix, :_add)]
 get_var_add(m, prefix::Symbol, element) = m[Symbol(prefix, :_add)][element, :]
 
 """
     get_var_rem(m, prefix::Symbol)
-
-Extracts the retired capacity variable with a given `prefix` from the model.
-"""
-get_var_rem(m, prefix::Symbol) = m[Symbol(prefix, :_rem)]
-"""
     get_var_rem(m, prefix::Symbol, element)
 
-When the type `element` is used as conditional input, it extracts only the variable for
-the specified element.
+Extracts the retired capacity variable with a given `prefix` from the model or only the
+variable for the specified `element`.
 """
+get_var_rem(m, prefix::Symbol) = m[Symbol(prefix, :_rem)]
 get_var_rem(m, prefix::Symbol, element) = m[Symbol(prefix, :_rem)][element, :]
 
 """
     get_var_invest_b(m, prefix::Symbol)
-
-Extracts the binary investment variable with a given `prefix` from the model.
-"""
-get_var_invest_b(m, prefix::Symbol) = m[Symbol(prefix, :_invest_b)]
-"""
     get_var_invest_b(m, prefix::Symbol, element)
 
-When the type `element` is used as conditional input, it extracts only the variable for
-the specified element.
+Extracts the binary investment variable with a given `prefix` from the model or only the
+variable for the specified `element`.
 """
+get_var_invest_b(m, prefix::Symbol) = m[Symbol(prefix, :_invest_b)]
 get_var_invest_b(m, prefix::Symbol, element) = m[Symbol(prefix, :_invest_b)][element, :]
 
 """
     get_var_remove_b(m, prefix::Symbol)
-
-Extracts the binary retirement variable with a given `prefix` from the model.
-"""
-get_var_remove_b(m, prefix::Symbol) = m[Symbol(prefix, :_remove_b)]
-"""
     get_var_remove_b(m, prefix::Symbol, element)
 
-When the type `element` is used as conditional input, it extracts only the variable for
-the specified element.
+Extracts the binary retirement variable with a given `prefix` from the model or only the
+variable for the specified `element`.
 """
+get_var_remove_b(m, prefix::Symbol) = m[Symbol(prefix, :_remove_b)]
 get_var_remove_b(m, prefix::Symbol, element) = m[Symbol(prefix, :_remove_b)][element, :]
 
 """
@@ -117,7 +89,8 @@ set_capex_value(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ) =
     set_capex_value(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, ::Investment)
 
 When no specialized method is defined for the investment mode, it calculates the capital
-cost based on the multiplication of the field `capex` in `inv_data` with the added capacity.
+cost based on the multiplication of the field `capex` in `inv_data` with the added capacity
+extracted from the model through the function [`get_var_add`](@ref).
 """
 function set_capex_value(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, ::Investment)
     # Deduce the required variable

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -235,7 +235,7 @@ end
         𝒯 = case[:T]
         𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
-        # Test that the investments is happening in one strategic period
+        # Test that the investments is happening in one investment period
         @test sum(value.(m[:cap_add][source, t_inv]) > 0 for t_inv ∈ 𝒯ᴵⁿᵛ) == 1
     end
 end


### PR DESCRIPTION
This PR focuses on improving the used docstrings for the most relevant functions for dispatch. This is accompanied by a restructuring of the internal library for an improved readability as well as replacing *strategic period* with *investment period*, While the former is the technical correct term from `TimeStruct`, I see it as simplifying the understanding by calling it *investment period* as we only allow investments within strategic periods.