### PR TITLE
Bugfix/Existing capacity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## Unversioned
 
+### Rework of initial capacities
+
+* Implemented potential for decreasing initial capacities.
+* This resulted in changes for `BinaryInvestment` and `FixedInvestment` in which the provided capacity fields come in addition to the existing capacities.
+  This allows for a reduction in the initial capacity.
+
 ### Rework of tests
 
 * The dependency of the tests from `EnergyModelsBase` was removed to avoid a hen-egg problem regarding registering.

--- a/src/EnergyModelsInvestments.jl
+++ b/src/EnergyModelsInvestments.jl
@@ -21,6 +21,7 @@ const TS = TimeStruct
 include(joinpath("structures", "investment_mode.jl"))
 include(joinpath("structures", "lifetime_mode.jl"))
 include(joinpath("structures", "investment_data.jl"))
+include(joinpath("structures", "legacy_constructors.jl"))
 
 # Core structure of the code
 include("model.jl")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -26,11 +26,13 @@ investment_data(element) = error(
 """
     start_cap(element, t_inv, inv_data::AbstractInvData, cap)
 
-Returns the starting capacity of the type `element` in the first investment period.
+Returns the starting capacity of the type `element` in investment period `t_inv` for
+capacity `cap`.
+
 If [`NoStartInvData`](@ref) is used for the starting capacity, it requires the definition
 of a method for the corresponding `element`.
 """
-start_cap(element, t_inv, inv_data::StartInvData, cap) = inv_data.initial
+start_cap(element, t_inv, inv_data::StartInvData, cap) = inv_data.initial[t_inv]
 start_cap(element, t_inv, inv_data::NoStartInvData, cap) = error(
     "The function `start_cap` is not implemented for $(typeof(element)) and " *
     "`NoStartInvData`. If you want to use `NoStartInvData` as investment data, " *

--- a/src/structures/investment_data.jl
+++ b/src/structures/investment_data.jl
@@ -46,25 +46,25 @@ end
 
 Investment data in which the initial capacity is specified in the `AbstractInvData`.
 The structure is similiar to [`NoStartInvData`](@ref) with the addition of the field
-**`initial::Real`**, see below.
+**`initial::TimeProfile`**, see below.
 
 # Fields in addition to [`NoStartInvData`](@ref)
-- **`initial::Real`** is the initial capacity.
+- **`initial::TimeProfile`** is the initial capacity as `TimeProfile`. Retirement of the
+  initial capacity can be achieved through a decreasing capacity.
 """
 struct StartInvData <: AbstractInvData
     capex::TimeProfile
     max_inst::TimeProfile
-    initial::Real
+    initial::TimeProfile
     inv_mode::Investment
     life_mode::LifetimeMode
 end
 function StartInvData(
     capex_trans::TimeProfile,
     trans_max_inst::TimeProfile,
-    initial::Real,
+    initial::TimeProfile,
     inv_mode::Investment,
 )
-
     return StartInvData(capex_trans, trans_max_inst, initial, inv_mode, UnlimitedLife())
 end
 

--- a/src/structures/investment_mode.jl
+++ b/src/structures/investment_mode.jl
@@ -14,7 +14,8 @@ Fixed investment in a given capacity.
 The model is forced to invest in the capacity provided by the field `cap`.
 
 # Fields
-- **`cap::TimeProfile`** is capacity used for the fixed investments.
+- **`cap::TimeProfile`** is capacity used for the fixed investments. These investments
+  come in addition to the existing capacity.
 """
 struct FixedInvestment <: Investment
     cap::TimeProfile
@@ -29,7 +30,8 @@ The chosen capacity within an investment period is given by the field `cap`.
 Binary investments introduce one binary variable for each investment period.
 
 # Fields
-- **`cap::TimeProfile`** is the capacity used for the fixed investments.
+- **`cap::TimeProfile`** is the capacity used for the binary investments. These investments
+  come in addition to the existing capacity.
 """
 struct BinaryInvestment <: Investment
     cap::TimeProfile

--- a/src/structures/legacy_constructors.jl
+++ b/src/structures/legacy_constructors.jl
@@ -1,0 +1,58 @@
+"""
+    StartInvData(
+        capex_trans::TimeProfile,
+        trans_max_inst::TimeProfile,
+        initial::Real,
+        inv_mode::Investment,
+        life_mode::LifetimeMode,    # This value is conditional
+    )
+
+Legacy constructor for a `StartInvData`.
+This version will be discontinued in the near future and replaced with the new version of
+in which the initial capacity is instead given as `TimeProfile`,
+
+See the *[documentation](https://energymodelsx.github.io/EnergyModelsInvestments.jl/stable/how-to/update-models/)*
+for further information regarding how you can translate your existing model to the new model.
+"""
+function StartInvData(
+    capex_trans::TimeProfile,
+    trans_max_inst::TimeProfile,
+    initial::Real,
+    inv_mode::Investment,
+)
+    @warn(
+        "The used implementation of a `StartInvData` will be discontinued in the near future.\n" *
+        "You have to only change the value of the field `initial` to a `FixedProfile` " *
+        "for utilizing the new version.",
+        maxlog = 1
+    )
+    return StartInvData(
+        capex_trans,
+        trans_max_inst,
+        FixedProfile(initial),
+        inv_mode,
+        UnlimitedLife(),
+    )
+end
+
+function StartInvData(
+    capex_trans::TimeProfile,
+    trans_max_inst::TimeProfile,
+    initial::Real,
+    inv_mode::Investment,
+    life_mode::LifetimeMode,
+)
+    @warn(
+        "The used implementation of a `StartInvData` will be discontinued in the near future.\n" *
+        "You have to only change the value of the field `initial` to a `FixedProfile` " *
+        "for utilizing the new version.",
+        maxlog = 1
+    )
+    return  StartInvData(
+        capex_trans,
+        trans_max_inst,
+        FixedProfile(initial),
+        inv_mode,
+        life_mode,
+    )
+end


### PR DESCRIPTION
in the current state, we do not allow for a reduction in the initial capacity, as outlined in #30. This is unsatisfactory, as it would require to use an additional node with a decreasing capacity. This is now changed in this PR in which the initial capacity is now required to be a `TimeProfile` with the potential for decreasing capacities. Hence, this PR closes #30.

A similar problem was experienced for `FixedInvestment` and `BinaryInvestment`. The rework of investments in [Version 0.6.0](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/releases/tag/v0.6.0) resulted in problems, when an initial capacity was specified, as outlined in #35. The proposed solution is to see the capacities provided through the investment modes as **in addition** to the existing (potentially decreasing) capacity. Hence, this PR closes as well #35. 

This change requires a major version increase. It will be included with the changes coming from the increased compatibility with `TimeStruct` v0.9