### PR TITLE
Fix/rolling life with multiple retirements in same investment period

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Release notes
 
+## Version 0.8.0 (2024-10-24)
+
+### Bugfix `RollingLife`
+
+* The lifetime mode `RollingLife` experienced problems in situations in which investments of multiple investment periods should be retired in the same investment period.
+* In this situation, we did not calculate the minimum removal correctly.
+* This is fixed and a test included to identify these problems in future iterations.
+
 ## Version 0.8.0 (2024-10-16)
 
 ### Rework of initial capacities

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsInvestments"
 uuid = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Dimitri Pinel <Dimitri.Pinel@sintef.no>"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/docs/src/how-to/use-emi.md
+++ b/docs/src/how-to/use-emi.md
@@ -94,7 +94,7 @@ function add_investment_constraints(
     inv_data::AbstractInvData,  # Investment data for the element
     cap,                        # Capacity that has investments
     prefix,                     # Used prefix in variable declaration
-    𝒯ᴵⁿᵛ::TS.StratPeriods,      # Strategic periods
+    𝒯ᴵⁿᵛ::TS.AbstractStratPers, # Strategic periods
     disc_rate::Float64,         # Discount rate in absolute values
 )
 ```


### PR DESCRIPTION
The lifetime mode `RollingLife` experienced problems in cases in which investments from multiple investment periods should be retired in the same investment period.
The problem was related to the minimum retirement constraint which was wrongly updated.

This is fixed in this PR. It is planned to implement the same fix both in 0.6 and 0.7.