### PR TITLE
Fix/rolling life with multiple retirements in same investment period - Version 0.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Since EnergyModelsInvestments doesn't have binary dependencies, 
+        # Since EnergyModelsInvestments doesn't have binary dependencies,
         # only test on a subset of possible platforms.
         include:
           - version: '1'  # The latest point-release (Linux)
@@ -22,18 +22,18 @@ jobs:
           - version: '1'  # The latest point-release (Windows)
             os: windows-latest
             arch: x64
-          - version: '1.9'  # 1.9 
+          - version: 'lts'  # lts 
             os: ubuntu-latest
             arch: x64
-          # - version: '1.9'  # 1.9
-          #   os: ubuntu-latest
-          #   arch: x86
+          - version: 'lts'  # lts
+            os: windows-latest
+            arch: x64
           # - version: 'nightly'
           #   os: ubuntu-latest
           #   arch: x64
     steps:
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -51,7 +51,3 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           depwarn: error
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
-        with:
-          file: lcov.info

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Version 0.7.2 (2024-10-24)
+
+* The lifetime mode `RollingLife` experienced problems in situations in which investments of multiple investment periods should be retired in the same investment period.
+* In this situation, we did not calculate the minimum removal correctly.
+* This is fixed, see also [PR 41](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/pull/41) for the incorporation of a test for the latest version of `EnergyModelsInvestments`.
+
 ## Version 0.7.1 (2024-08-26)
 
 * Bugfix in `RollingLife` in a situation, in which the duration of a strategic period equals the lifetime of the technology.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsInvestments"
 uuid = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Dimitri Pinel <Dimitri.Pinel@sintef.no>"]
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/src/model.jl
+++ b/src/model.jl
@@ -255,39 +255,55 @@ function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rat
     # Calculate the CAPEX value based on the chosen investment mode
     capex_val = set_capex_value(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ)
 
+    # Initialize a dictionary for the removal of capacity
+    rem_dict = Dict(t_inv => eltype(𝒯ᴵⁿᵛ)[] for t_inv ∈ 𝒯ᴵⁿᵛ)
+
     for t_inv ∈ 𝒯ᴵⁿᵛ
         # Extract the values
         lifetime_val = lifetime(inv_data, t_inv)
 
+        # Initialization of the t_inv_rem and the remaining lifetime
+        # t_inv_rem represents the last investment period in which the remaining lifetime
+        # is sufficient to cover the whole investment period duration.
+        t_inv_rem = t_inv
+
         # If lifetime is shorter than the sp duration, we apply the method for PeriodLife
         # to account for the required reinvestments
         if lifetime_val < duration_strat(t_inv)
-            set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rate, PeriodLife())
+            capex_disc = set_capex_discounter(duration_strat(t_inv), lifetime_val, disc_rate)
+            @constraint(m, var_capex[t_inv] == capex_val[t_inv] * capex_disc)
+            push!(rem_dict[t_inv_rem], t_inv)
 
-            # If lifetime is equal to sp duration we only need to invest once and there is no
-            # rest value. The invested capacity is removed at the end of the strategic period
+        # If lifetime is equal to sp duration we only need to invest once and there is no
+        # rest value. The invested capacity is removed at the end of the investment period
         elseif lifetime_val == duration_strat(t_inv)
             @constraint(m, var_capex[t_inv] == capex_val[t_inv])
-            @constraint(m, var_rem[t_inv] == var_add[t_inv])
+            push!(rem_dict[t_inv_rem], t_inv)
 
-            # If lifetime is longer than sp duration, the capacity can roll over to the next sp
+        # If lifetime is longer than sp duration, the capacity can roll over to the next sp
         elseif lifetime_val > duration_strat(t_inv)
-            # Initialization of the ante_sp and the remaining lifetime
-            # ante_sp represents the last sp in which the remaining lifetime is sufficient
-            # to cover the whole sp duration.
-            ante_sp = t_inv
+            # Initialization of the the remaining lifetime
             remaining_lifetime = lifetime_val
+            bool_lifetime = true
 
-            # Iteration to identify sp in which remaining_lifetime is smaller than sp duration
+            # Iteration to identify investment period in which the remaining lifetime is
+            # smaller than its duration
             for sp ∈ 𝒯ᴵⁿᵛ
-                if sp >= t_inv
+                if sp ≥ t_inv
                     if remaining_lifetime < duration_strat(sp)
                         break
                     end
                     remaining_lifetime -= duration_strat(sp)
-                    ante_sp = sp
+                    t_inv_rem = sp
+                    if sp == last(𝒯ᴵⁿᵛ) && remaining_lifetime > 0
+                        bool_lifetime = false
+                    end
                 end
             end
+
+            # If the remaining life is larger than 0 at the end of the analysis horizon, we
+            # do not remove the capacity
+            bool_lifetime && push!(rem_dict[t_inv_rem], t_inv)
 
             # Calculation of cost and rest value
             capex_disc = (
@@ -296,11 +312,12 @@ function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rat
                 (1 + disc_rate)^(-(lifetime_val - remaining_lifetime))
             )
             @constraint(m, var_capex[t_inv] == capex_val[t_inv] * capex_disc)
-
-            # Capacity to be removed when remaining_lifetime < duration_years, i.e., in ante_sp
-            if ante_sp.sp < length(𝒯ᴵⁿᵛ)
-                @constraint(m, var_rem[ante_sp] >= var_add[t_inv])
-            end
+        end
+    end
+    for (t_inv_rem, t_inv_vec) ∈ rem_dict
+        # Capacity to be removed when remaining_lifetime < duration_years, i.e., in t_inv_rem
+        if !isempty(t_inv_vec)
+            @constraint(m, var_rem[t_inv_rem] ≥ sum(var_add[t_inv] for t_inv ∈ t_inv_vec))
         end
     end
 end


### PR DESCRIPTION
This PR mirrors #41  for the supported version 0.7. It will be merged once the fix for 0.8 is accepted.
It also includes updates to the CI due to the rule set.