### PR TITLE
Improved the structure

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,16 +2,30 @@
 
 ## Unversioned
 
-### Added support for early capacity retirement
+### Breaking changes
+
+#### Added support for early capacity retirement
 
 * Early capacity retirement implemented with zero cost associated with it.
 * This fixes issues with `FixedInvestment` and lifetime calculations.
 
-### Added support for `TwoLevelTree`
+#### Changed arguments for main function
+
+* Move from `𝒯ᴵⁿᵛ::TS.AbstractStratPers` to `𝒯::Union{TwoLevel, TwoLevelTree}` in `add_investment_constraints`.
+* Aim with change is to avoid calling fields of `TwoLeveltree` for the implementation.
+* Adjustments to existing models outlined in the documentation.
+
+### Additional changes
+
+#### Added support for `TwoLevelTree`
 
 * The previous version did not support `TwoLevelTree` structures due to retirement constraints.
 * Retirement constraints are adjusted to reflect retirement in each branch of the tree structure.
 * Early retirement not yet supported for the nodes.
+
+#### Miscellaneous
+
+* Simplified some parts of the code by reusing other functions.
 
 ## Version 0.8.1 (2024-10-24)
 

--- a/docs/src/how-to/update-models.md
+++ b/docs/src/how-to/update-models.md
@@ -5,6 +5,25 @@ Hence, there are frequently breaking changes occuring, although we plan to keep 
 This document is designed to provide users with information regarding how they have to adjust their models to keep compatibility to the latest changes.
 We will as well implement information regarding the adjustment of extension packages, although this is more difficult due to the vast majority of potential changes.
 
+## [Adjustments from 0.8.x](@id how_to-update-08)
+
+We changed the arguments of the function [`add_investment_constraints`](@ref EMI.add_investment_constraints) from `𝒯ᴵⁿᵛ::TS.AbstractStratPers` to `𝒯::Union{TwoLevel, TwoLevelTree}`.
+The change removes the requirement to go into the subfields of `StratTreeNodes` to access the original `TwoLevelTree` to create the strategic scenarios.
+
+The only required change is to change the function call from, *e.g.*,
+
+```julia
+add_investment_constraints(m, n, inv_data, nothing, :cap, 𝒯ᴵⁿᵛ, disc_rate)
+```
+
+to
+
+```julia
+add_investment_constraints(m, n, inv_data, nothing, :cap, 𝒯, disc_rate)
+```
+
+The same holds if you created a new lifetime mode.
+
 ## [Adjustments from 0.5.x](@id how_to-update-05)
 
 The following changes obly affect older models using `EnergyModelsBase` and `EnergyModelsGeography`.

--- a/src/model.jl
+++ b/src/model.jl
@@ -24,9 +24,9 @@ options.
   element can be used. In `EnergyModelsBase`, the individual element is either a `Node` or a
   `TransmissionMode`.
 - `inv_data::AbstractInvData`: the investment data for the node and capacity `cap`.
+- `cap`: the field that is used if several capacities are provided.
 - `prefix`: the prefix used for variables for this element. This argument is used for
   extracting the individual investment variables.
-- `cap`: the field that is used if several capacities are provided.
 - `𝒯ᴵⁿᵛ::TS.AbstractStratPers`: the strategic periods structure. It can be created from both
   a `TwoLevel` or `TwoLevelTree` structure.
 - `disc_rate`: the discount rate used in the lifetime calculation for reinvestment and
@@ -56,8 +56,10 @@ function add_investment_constraints(
         # Link capacity usage to installed capacity
         @constraint(m, [t ∈ t_inv], var_inst[t] == var_current[t_inv])
 
+        # Set the upper bound of the variable
+        set_upper_bound(var_current[t_inv], max_installed(inv_data, t_inv))
+
         # Capacity updating
-        @constraint(m, var_current[t_inv] ≤ max_installed(inv_data, t_inv))
         if isnothing(t_inv_prev)
             @constraint(m, var_current[t_inv] == val_start_cap[t_inv] + var_add[t_inv])
         else
@@ -69,7 +71,7 @@ function add_investment_constraints(
             @constraint(m,
                 var_current[t_inv] ≤
                     val_start_cap[t_inv] - val_start_cap[t_inv_prev] +
-                    sum(var_add[sp] for sp ∈ 𝒯ᴵⁿᵛ if sp ∈ life_dict[t_inv])
+                    sum(var_add[sp] for sp ∈ life_dict[t_inv])
             )
         end
     end
@@ -115,8 +117,10 @@ function set_capacity_installation(m, element, prefix, 𝒯ᴵⁿᵛ, val_start_
     var_add = get_var_add(m, prefix, element)
 
     # Set the limits
-    @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_add[t_inv] ≤ max_add(inv_mode, t_inv))
-    @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_add[t_inv] ≥ min_add(inv_mode, t_inv))
+    for t_inv ∈ 𝒯ᴵⁿᵛ
+        set_lower_bound(var_add[t_inv], min_add(inv_mode, t_inv))
+        set_upper_bound(var_add[t_inv], max_add(inv_mode, t_inv))
+    end
 end
 
 function set_capacity_installation(m, element, prefix, 𝒯ᴵⁿᵛ, val_start_cap, inv_mode::BinaryInvestment)
@@ -249,20 +253,20 @@ function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rat
     var_rem = get_var_rem(m, prefix, element)
 
     # The capacity is limited to the end of the study. Reinvestments are included
-    capex_disc = StrategicProfile([
+    disc_fact = StrategicProfile([
         set_capex_discounter(
             remaining(t_inv, 𝒯ᴵⁿᵛ),
             lifetime(inv_data, t_inv), disc_rate
         ) for t_inv ∈ 𝒯ᴵⁿᵛ
     ])
     capex_val = set_capex_value(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ)
-    @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_capex[t_inv] == capex_val[t_inv] * capex_disc[t_inv])
+    @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_capex[t_inv] == capex_val[t_inv] * disc_fact[t_inv])
 
     # All capacities that require reinvestments or should be retired at the end of the study
     # are removed
     @constraint(m,
-        sum(var_rem[t_inv] for t_inv ∈ 𝒯ᴵⁿᵛ) ==
-            sum(var_add[t_inv] for t_inv ∈ 𝒯ᴵⁿᵛ if capex_disc[t_inv] ≥ 1.0)
+        sum(var_rem[t_inv] for t_inv ∈ 𝒯ᴵⁿᵛ) ≥
+            sum(var_add[t_inv] for t_inv ∈ 𝒯ᴵⁿᵛ if disc_fact[t_inv] ≥ 1.0)
     )
 end
 function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rate, ::PeriodLife)
@@ -274,14 +278,14 @@ function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rat
     # The capacity is limited to the current sp. It has to be removed in the next sp.
     # The capacity removal variable is corresponding to the removal of the capacity at the
     # end of the investment period. Hence, we have to enforce `var_rem[t_inv] == var_add[t_inv]`
-    capex_disc = StrategicProfile([
+    disc_fact = StrategicProfile([
         set_capex_discounter(
             duration_strat(t_inv),
             lifetime(inv_data, t_inv), disc_rate
         ) for t_inv ∈ 𝒯ᴵⁿᵛ
     ])
     capex_val = set_capex_value(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ)
-    @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_capex[t_inv] == capex_val[t_inv] * capex_disc[t_inv])
+    @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_capex[t_inv] == capex_val[t_inv] * disc_fact[t_inv])
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_rem[t_inv] == var_add[t_inv])
 end
 function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rate, lifetime_mode::RollingLife)
@@ -293,7 +297,7 @@ function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rat
     # Calculate the CAPEX value based on the chosen investment mode
     capex_val = set_capex_value(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ)
 
-    # Calculate the CAPEX value based on the chosen investment mode
+    # Initialize the capacity removal dictionary
     rem_dict = _init_rem_dict(𝒯ᴵⁿᵛ)
 
     # Depending on the lifetime, different approaches are used through the function
@@ -301,10 +305,10 @@ function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rat
     # the lifetime of the element and the duration. The outer for loop is required to
     # differentiate between `TwoLevel` and `TwoLevelTree`
     for t_inv ∈ 𝒯ᴵⁿᵛ
-        capex_disc = capacity_removal!(
+        disc_fact = capacity_removal!(
             rem_dict, t_inv, lifetime(inv_data, t_inv), 𝒯ᴵⁿᵛ, disc_rate
         )
-        @constraint(m, var_capex[t_inv] == capex_val[t_inv] * capex_disc)
+        @constraint(m, var_capex[t_inv] == capex_val[t_inv] * disc_fact)
     end
     # Requirement for total capacity removal given the investments whose lifetime ends within
     # the study period

--- a/src/model.jl
+++ b/src/model.jl
@@ -52,7 +52,7 @@ function add_investment_constraints(
 
     # Identify the investment periods relevant for capacity addition in each investment period
     life_dict = Dict(t_inv => eltype(𝒯ᴵⁿᵛ)[] for t_inv ∈ 𝒯ᴵⁿᵛ)
-    populate_lifetime_vectors!(life_dict, lifetime_mode(inv_data), 𝒯ᴵⁿᵛ)
+    populate_lifetime_vectors!(life_dict, lifetime_mode(inv_data), 𝒯)
 
     for (t_inv_prev, t_inv) ∈ withprev(𝒯ᴵⁿᵛ)
         # Link capacity usage to installed capacity

--- a/src/model.jl
+++ b/src/model.jl
@@ -27,8 +27,7 @@ options.
 - `cap`: the field that is used if several capacities are provided.
 - `prefix`: the prefix used for variables for this element. This argument is used for
   extracting the individual investment variables.
-- `𝒯ᴵⁿᵛ::TS.AbstractStratPers`: the strategic periods structure. It can be created from both
-  a `TwoLevel` or `TwoLevelTree` structure.
+- `𝒯::Union{TwoLevel, TwoLevelTree}`: the time structure.
 - `disc_rate`: the discount rate used in the lifetime calculation for reinvestment and
   end of life calculations.
 """
@@ -38,9 +37,12 @@ function add_investment_constraints(
     inv_data::AbstractInvData,
     cap,
     prefix,
-    𝒯ᴵⁿᵛ::TS.AbstractStratPers,
+    𝒯::Union{TwoLevel, TwoLevelTree},
     disc_rate::Float64,
 )
+    # Extract the strategic periods
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+
     # Deduce required variables and values
     var_current = get_var_current(m, prefix, element)
     var_inst = get_var_inst(m, prefix, element)

--- a/src/model.jl
+++ b/src/model.jl
@@ -81,7 +81,7 @@ function add_investment_constraints(
     set_capacity_installation(m, element, prefix, 𝒯ᴵⁿᵛ, val_start_cap, investment_mode(inv_data))
 
     # Constraints for the CAPEX calculation
-    set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rate)
+    set_capacity_cost(m, element, inv_data, prefix, 𝒯, disc_rate)
 end
 
 """
@@ -205,7 +205,7 @@ function set_capacity_installation(m, element, prefix, 𝒯ᴵⁿᵛ, val_start_
 end
 
 """
-    set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rate)
+    set_capacity_cost(m, element, inv_data, prefix, 𝒯, disc_rate)
 
 Function for creating constraints for the variable `var_capex` dependent on the chosen
 [`Investment`](@ref) and [`LifetimeMode`](@ref).
@@ -231,28 +231,30 @@ It implements different versions of the lifetime implementation:
     [`LifetimeMode`](@ref). If not, you have to make certain that the function
     [`lifetime`](@ref) is applicable for your lifetime mode.
 """
-set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rate) = set_capacity_cost(
+set_capacity_cost(m, element, inv_data, prefix, 𝒯, disc_rate) = set_capacity_cost(
     m,
     element,
     inv_data,
     prefix,
-    𝒯ᴵⁿᵛ,
+    𝒯,
     disc_rate,
     lifetime_mode(inv_data),
 )
-function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rate, ::UnlimitedLife)
-    # Deduce the required variables
+function set_capacity_cost(m, element, inv_data, prefix, 𝒯, disc_rate, ::UnlimitedLife)
+    # Deduce the required variables and structures
     var_capex = get_var_capex(m, prefix, element)
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # The capacity has an unlimited lifetime, one investment at the beginning of t_inv
     capex_val = set_capex_value(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ)
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_capex[t_inv] == capex_val[t_inv])
 end
-function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rate, ::StudyLife)
-    # Deduce the required variables
+function set_capacity_cost(m, element, inv_data, prefix, 𝒯, disc_rate, ::StudyLife)
+    # Deduce the required variables and structures
     var_capex = get_var_capex(m, prefix, element)
     var_add = get_var_add(m, prefix, element)
     var_rem = get_var_rem(m, prefix, element)
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # The capacity is limited to the end of the study. Reinvestments are included
     disc_fact = StrategicProfile([
@@ -271,11 +273,12 @@ function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rat
             sum(var_add[t_inv] for t_inv ∈ 𝒯ᴵⁿᵛ if disc_fact[t_inv] ≥ 1.0)
     )
 end
-function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rate, ::PeriodLife)
-    # Deduce the required variables
+function set_capacity_cost(m, element, inv_data, prefix, 𝒯, disc_rate, ::PeriodLife)
+    # Deduce the required variables and structures
     var_capex = get_var_capex(m, prefix, element)
     var_add = get_var_add(m, prefix, element)
     var_rem = get_var_rem(m, prefix, element)
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # The capacity is limited to the current sp. It has to be removed in the next sp.
     # The capacity removal variable is corresponding to the removal of the capacity at the
@@ -290,17 +293,18 @@ function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rat
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_capex[t_inv] == capex_val[t_inv] * disc_fact[t_inv])
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ], var_rem[t_inv] == var_add[t_inv])
 end
-function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rate, lifetime_mode::RollingLife)
-    # Deduce the required variables
+function set_capacity_cost(m, element, inv_data, prefix, 𝒯, disc_rate, ::RollingLife)
+    # Deduce the required variables and structures
     var_capex = get_var_capex(m, prefix, element)
     var_add = get_var_add(m, prefix, element)
     var_rem = get_var_rem(m, prefix, element)
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Calculate the CAPEX value based on the chosen investment mode
     capex_val = set_capex_value(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ)
 
     # Initialize the capacity removal dictionary
-    rem_dict = _init_rem_dict(𝒯ᴵⁿᵛ)
+    rem_dict = _init_rem_dict(𝒯)
 
     # Depending on the lifetime, different approaches are used through the function
     # `capacity_removal!` where the rest value (or additional costs) are calculated given
@@ -308,7 +312,7 @@ function set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rat
     # differentiate between `TwoLevel` and `TwoLevelTree`
     for t_inv ∈ 𝒯ᴵⁿᵛ
         disc_fact = capacity_removal!(
-            rem_dict, t_inv, lifetime(inv_data, t_inv), 𝒯ᴵⁿᵛ, disc_rate
+            rem_dict, t_inv, lifetime(inv_data, t_inv), 𝒯, disc_rate
         )
         @constraint(m, var_capex[t_inv] == capex_val[t_inv] * disc_fact)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -140,10 +140,10 @@ is given by `PeriodLife` and `StudyLife`.
 """
 function set_capex_discounter(years, lifetime, disc_rate)
     N_inv = ceil(years / lifetime)
-    capex_disc =
+    disc_fact =
         sum((1 + disc_rate)^(-n_inv * lifetime) for n_inv ∈ 0:N_inv-1) -
         ((N_inv * lifetime - years) / lifetime) * (1 + disc_rate)^(-years)
-    return capex_disc
+    return disc_fact
 end
 
 """
@@ -182,11 +182,11 @@ function capacity_removal!(rem_dict::Dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ::T
     end
 
     # Calculation of the averaged discounting factor considering different branches
-    capex_disc = 0
+    disc_fact = 0
     for (scen, disc) ∈ disc_dict
-        capex_disc += disc * scen.probability
+        disc_fact += disc * scen.probability
     end
-    return capex_disc
+    return disc_fact
 end
 function _cap_rem!(rem_dict::Dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ::Union{TS.StratPers, TS.ScenTreeNodes}, disc_rate)
     # Initialize the variable used for calculating the remaining life at the end of a
@@ -215,18 +215,16 @@ function _cap_rem!(rem_dict::Dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ::Union{TS.
     if bool_shorter
         # If lifetime is shorter than the sp duration, we apply the method for PeriodLife
         # to account for the required reinvestments
-        capex_disc = set_capex_discounter(duration_strat(t_inv), lifetime_val, disc_rate)
+        disc_fact = set_capex_discounter(duration_strat(t_inv), lifetime_val, disc_rate)
     else
         # If lifetime is equal or longer than sp duration, the discounting rate is including
         # a potential rest value, depending on the remaining lifetime at the end of the
         # last period it is active.
-        capex_disc = (
-            1 -
-            (remaining_lifetime / lifetime_val) *
-            (1 + disc_rate)^(-(lifetime_val - remaining_lifetime))
+        disc_fact = set_capex_discounter(
+            lifetime_val-remaining_lifetime, lifetime_val, disc_rate
         )
     end
-    return capex_disc
+    return disc_fact
 end
 
 """
@@ -256,10 +254,10 @@ function populate_lifetime_vectors!(life_dict::Dict, lifetime_mode::RollingLife,
             push!(life_dict[t_inv], t_inv)
         else
             for sp ∈ 𝒯ᴵⁿᵛ
-                if sp ≥ t_inv
-                    dur = sum(duration_strat(spp) for spp ∈ 𝒯ᴵⁿᵛ if spp ≤ sp && spp ≥ t_inv; init = 0)
-                    if dur ≤ lifetime(lifetime_mode, t_inv)
-                        push!(life_dict[sp], t_inv)
+                if sp ≤ t_inv
+                    dur = sum(duration_strat(spp) for spp ∈ 𝒯ᴵⁿᵛ if spp ≤ t_inv && spp ≥ sp; init = 0)
+                    if dur ≤ lifetime(lifetime_mode, sp)
+                        push!(life_dict[t_inv], sp)
                     end
                 end
             end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -228,26 +228,36 @@ function _cap_rem!(rem_dict::Dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ::Union{TS.
 end
 
 """
+    populate_lifetime_vectors!(life_dict::Dict, lifetime_mode::LifetimeMode, 𝒯::TwoLevel)
+    populate_lifetime_vectors!(life_dict::Dict, lifetime_mode::LifetimeMode, 𝒯::TwoLevelTree)
+
     populate_lifetime_vectors!(life_dict::Dict, _::PeriodLife, 𝒯ᴵⁿᵛ::TS.AbstractStratPers)
-    populate_lifetime_vectors!(life_dict::Dict, _::Union{UnlimitedLife, StudyLife}, 𝒯ᴵⁿᵛ::Union{TS.StratPers, TS.ScenTreeNodes})
-    populate_lifetime_vectors!(life_dict::Dict, lifetime_mode::RollingLife, 𝒯ᴵⁿᵛ::Union{TS.StratPers, TS.ScenTreeNodes})
-    populate_lifetime_vectors!(life_dict::Dict, lifetime_mode::Union{UnlimitedLife, StudyLife, RollingLife}, 𝒯ᴵⁿᵛ::TS.StratTreeNodes)
+    populate_lifetime_vectors!(life_dict::Dict, _::Union{UnlimitedLife, StudyLife}, 𝒯ᴵⁿᵛ::TS.AbstractStratPers)
+    populate_lifetime_vectors!(life_dict::Dict, lifetime_mode::RollingLife, 𝒯ᴵⁿᵛ::TS.AbstractStratPers)
 
 Populate the `life_dict` with the vectors of available time periods for capacity additions
 in each strategic period. The update allows for both [`TwoLevel`](@extref TimeStruct.TwoLevel)
 and [`TwoLevelTree`](@extref TimeStruct.TwoLevelTree) time structures.
 """
+populate_lifetime_vectors!(life_dict::Dict, lifetime_mode::LifetimeMode, 𝒯::TwoLevel) =
+    populate_lifetime_vectors!(life_dict, lifetime_mode, strategic_periods(𝒯))
+function populate_lifetime_vectors!(life_dict::Dict, lifetime_mode::LifetimeMode, 𝒯::TwoLevelTree)
+    for scen ∈ strategic_scenarios(𝒯)
+        populate_lifetime_vectors!(life_dict, lifetime_mode, strategic_periods(scen))
+    end
+    unique!.(values(life_dict))
+end
 function populate_lifetime_vectors!(life_dict::Dict, _::PeriodLife, 𝒯ᴵⁿᵛ::TS.AbstractStratPers)
     for t_inv ∈ 𝒯ᴵⁿᵛ
         push!(life_dict[t_inv], t_inv)
     end
 end
-function populate_lifetime_vectors!(life_dict::Dict, _::Union{UnlimitedLife, StudyLife}, 𝒯ᴵⁿᵛ::Union{TS.StratPers, TS.ScenTreeNodes})
+function populate_lifetime_vectors!(life_dict::Dict, _::Union{UnlimitedLife, StudyLife}, 𝒯ᴵⁿᵛ::TS.AbstractStratPers)
     for t_inv ∈ 𝒯ᴵⁿᵛ
         append!(life_dict[t_inv], [sp for sp ∈ 𝒯ᴵⁿᵛ if sp ≤ t_inv])
     end
 end
-function populate_lifetime_vectors!(life_dict::Dict, lifetime_mode::RollingLife, 𝒯ᴵⁿᵛ::Union{TS.StratPers, TS.ScenTreeNodes})
+function populate_lifetime_vectors!(life_dict::Dict, lifetime_mode::RollingLife, 𝒯ᴵⁿᵛ::TS.AbstractStratPers)
     for t_inv ∈ 𝒯ᴵⁿᵛ
         lifetime_val = lifetime(lifetime_mode, t_inv)
         if lifetime_val ≤ duration_strat(t_inv)
@@ -263,10 +273,4 @@ function populate_lifetime_vectors!(life_dict::Dict, lifetime_mode::RollingLife,
             end
         end
     end
-end
-function populate_lifetime_vectors!(life_dict::Dict, lifetime_mode::Union{UnlimitedLife, StudyLife, RollingLife}, 𝒯ᴵⁿᵛ::TS.StratTreeNodes)
-    for scen ∈ strategic_scenarios(𝒯ᴵⁿᵛ.ts)
-        populate_lifetime_vectors!(life_dict, lifetime_mode, strategic_periods(scen))
-    end
-    unique!.(values(life_dict))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -147,18 +147,23 @@ function set_capex_discounter(years, lifetime, disc_rate)
 end
 
 """
-    _init_rem_dict(𝒯ᴵⁿᵛ::TS.StratPers)
-    _init_rem_dict(𝒯ᴵⁿᵛ::TS.StratTreeNodes)
+    _init_rem_dict(𝒯::TwoLevel)
+    _init_rem_dict(𝒯::TwoLevelTree)
 
 Return the initialized removal dictionary depending on the chosen time structure.
 """
-_init_rem_dict(𝒯ᴵⁿᵛ::TS.StratPers) =  Dict(𝒯ᴵⁿᵛ => eltype(𝒯ᴵⁿᵛ)[])
-_init_rem_dict(𝒯ᴵⁿᵛ::TS.StratTreeNodes) =
-    Dict(strategic_periods(scen) => eltype(strategic_periods(scen))[] for scen ∈ strategic_scenarios(𝒯ᴵⁿᵛ.ts))
+function _init_rem_dict(𝒯::TwoLevel)
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
+    return Dict(𝒯ᴵⁿᵛ => eltype(𝒯ᴵⁿᵛ)[])
+end
+_init_rem_dict(𝒯::TwoLevelTree) =
+    Dict(strategic_periods(scen) => eltype(strategic_periods(scen))[] for scen ∈ strategic_scenarios(𝒯))
 
 """
-    capacity_removal!(rem_dict::Dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ::TS.StratTreeNodes, disc_rate)
-    capacity_removal!(rem_dict::Dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ::Union{TS.StratPers, TS.StrategicScenario}, disc_rate)
+    capacity_removal!(rem_dict::Dict, t_inv, lifetime_val, 𝒯::TwoLevelTree, disc_rate)
+    capacity_removal!(rem_dict::Dict, t_inv, lifetime_val, 𝒯::TwoLevel, disc_rate)
+
+    capacity_removal!(rem_dict::Dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, disc_rate)
 
 Update the dictionary used for calculation of capacity removal and return the value used for
 discounting the investment costs given a lifetime differing from the resolution of the time
@@ -167,17 +172,18 @@ structure.
 Both the dictionary and the discounting value take into account potentially differing
 strategic durations in a [`TwoLevelTree`](@extref TimeStruct.TwoLevelTree) time structure.
 """
-function capacity_removal!(rem_dict::Dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ::TS.StratPers, disc_rate)
+function capacity_removal!(rem_dict::Dict, t_inv, lifetime_val, 𝒯::TwoLevel, disc_rate)
+    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
     return _cap_rem!(rem_dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ, disc_rate)
 end
-function capacity_removal!(rem_dict::Dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ::TS.StratTreeNodes, disc_rate)
+function capacity_removal!(rem_dict::Dict, t_inv, lifetime_val, 𝒯::TwoLevelTree, disc_rate)
     # Calculate the values and initiate the new dictionary
-    strat_scens = strategic_scenarios(𝒯ᴵⁿᵛ.ts)
+    strat_scens = strategic_scenarios(𝒯)
     disc_dict = Dict()
     for scen ∈ strat_scens
-        sps = strategic_periods(scen)
-        if t_inv ∈ sps
-            disc_dict[scen] = _cap_rem!(rem_dict, t_inv, lifetime_val, sps, disc_rate)
+        𝒯ᴵⁿᵛ = strategic_periods(scen)
+        if t_inv ∈ 𝒯ᴵⁿᵛ
+            disc_dict[scen] = _cap_rem!(rem_dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ, disc_rate)
         end
     end
 
@@ -188,7 +194,7 @@ function capacity_removal!(rem_dict::Dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ::T
     end
     return disc_fact
 end
-function _cap_rem!(rem_dict::Dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ::Union{TS.StratPers, TS.ScenTreeNodes}, disc_rate)
+function _cap_rem!(rem_dict::Dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ::TS.AbstractStratPers, disc_rate)
     # Initialize the variable used for calculating the remaining life at the end of a
     # strategic period and the boolean for identifying whether the capacity must be removed
     remaining_lifetime = lifetime_val
@@ -219,7 +225,7 @@ function _cap_rem!(rem_dict::Dict, t_inv, lifetime_val, 𝒯ᴵⁿᵛ::Union{TS.
     else
         # If lifetime is equal or longer than sp duration, the discounting rate is including
         # a potential rest value, depending on the remaining lifetime at the end of the
-        # last period it is active.
+        # last period it is active
         disc_fact = set_capex_discounter(
             lifetime_val-remaining_lifetime, lifetime_val, disc_rate
         )

--- a/test/test_lifetime.jl
+++ b/test/test_lifetime.jl
@@ -42,13 +42,13 @@ end
     # Explicit calculation of CAPEX
     # 1. Investments in the first investment period require reinvestments in current period +2 (3).
     #    The reinvestments use their complete lifetime.
-    # 2. Investments in the second investment period require reinvestments in current period +2 (3).
+    # 2. Investments in the second investment period require reinvestments in current period +2 (4).
     #    The reinvestments use half of their lifetime (-0.5). Due to linear deprecation,
     #    we still have a discounted final value.
-    # 3. Investments in the second investment period require do not require reinvestments
-    #    and use their complete lifetime.
-    # 4. Investments in the second investment period require do not require reinvestments
-    #    and use half of their lifetime (-0.5). Due to linear deprecation, we still have a
+    # 3. Investments in the third investment period do not require reinvestments and use
+    #    their complete lifetime.
+    # 4. Investments in the forth investment period do not require reinvestments and use
+    #    half of their lifetime (-0.5). Due to linear deprecation, we still have a
     #    discounted final value.
     capex = StrategicProfile([
         10 * (1 + disc_rates[3]),
@@ -66,6 +66,69 @@ end
 
         # Test the capacities are removed in the end, if it is required
         @test value.(m[:cap_rem][n, last(𝒯ᴵⁿᵛ)]) ≈ 30
+
+        # Test that the CAPEX is correctly calculated
+        # - set_capex_discounter(years, lifetime, disc_rate)
+        @test all(
+            value.(m[:cap_capex])[n, t_inv] ≈
+                value.(m[:cap_add])[n, t_inv] * EMI.capex(inv_data, t_inv) *
+                EMI.set_capex_discounter(
+                    EMI.remaining(t_inv, 𝒯ᴵⁿᵛ),
+                    EMI.lifetime(inv_data, t_inv),
+                    para[:disc_rate]
+        ) for t_inv ∈ 𝒯ᴵⁿᵛ)
+        @test all(value.(m[:cap_capex])[n, t_inv] ≈ capex[t_inv] for t_inv ∈ 𝒯ᴵⁿᵛ)
+    end
+end
+
+@testset "StudyLife - Early retirement" begin
+    # Creation and solving of the model
+    inv_data = NoStartInvData(
+        FixedProfile(1000),
+        FixedProfile(40),
+        ContinuousInvestment(FixedProfile(0), FixedProfile(15)),
+        StudyLife(FixedProfile(20))
+    )
+    demand = StrategicProfile([10,10,30,0])
+    fixed_opex = FixedProfile(10)
+    m, para = simple_model(;inv_data, demand, fixed_opex)
+
+    # Extraction of required data
+    n = para[:node]
+    𝒯 = para[:T]
+    𝒯ᴵⁿᵛ = strat_periods(𝒯)
+    inv_data = para[:inv_data]
+    disc_rates = [objective_weight(t_inv, Discounter(para[:disc_rate], 𝒯)) for t_inv ∈ 𝒯ᴵⁿᵛ]
+
+    # Explicit calculation of CAPEX
+    # 1. Investments in the first investment period require reinvestments in current period +2 (3).
+    #    The reinvestments use their complete lifetime.
+    # 2. Investments in the second investment period require reinvestments in current period +2 (5).
+    #    The reinvestments use half of their lifetime (-0.5). Due to linear deprecation,
+    #    we still have a discounted final value.
+    # 3. Investments in the third investment period do not require reinvestments and use
+    #    their complete lifetime.
+    # 4. No investments occur in the forth investment period
+    capex = StrategicProfile([
+        10 * (1 + disc_rates[3]),
+        5 * (1 + (disc_rates[3] - 0.5 * disc_rates[4])),
+        15,
+        0,
+    ])*1e3
+    invest = StrategicProfile([10, 5, 15, 0])
+
+    # Capacity removal
+    # All capacity is removed at the end of the third investment period to avoid fixed OPEX
+    removal = StrategicProfile([0, 0, 30, 0])
+
+    # Tests of the lifetime calculation
+    # - set_capacity_cost(m, element, inv_data, prefix, 𝒯ᴵⁿᵛ, disc_rate, ::StudyLife)
+    @testset "Lifetime calculations" begin
+        # Test the additions are following the predicted value
+        @test all(value.(m[:cap_add][n, t_inv]) ≈ invest[t_inv] for t_inv ∈ 𝒯ᴵⁿᵛ)
+
+        # Test the capacities are removed in the respective period
+        @test all(value.(m[:cap_rem][n,t_inv]) ≈ removal[t_inv] for t_inv ∈ 𝒯ᴵⁿᵛ)
 
         # Test that the CAPEX is correctly calculated
         # - set_capex_discounter(years, lifetime, disc_rate)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -60,7 +60,7 @@ function simple_model(;
     @constraint(m, [t ∈ 𝒯], m[:cap_use][n, t] == m[:cap_inst][n, t])
 
     # Add the investment constraints
-    EMI.add_investment_constraints(m, n, inv_data, nothing, :cap, 𝒯ᴵⁿᵛ, disc_rate)
+    EMI.add_investment_constraints(m, n, inv_data, nothing, :cap, 𝒯, disc_rate)
 
     # Calculation of the OPEX contribution
     @constraint(m, [t_inv ∈ 𝒯ᴵⁿᵛ],


### PR DESCRIPTION
This PR replaces the function call for `add_investment_constraints` from `𝒯ᴵⁿᵛ::TS.AbstractStratPers` to `𝒯::Union{TwoLevel, TwoLevelTree}`. This change is due to the requirement in #48 to extract the `TwoLevelTree` from the fields of `StratTreeNodes` to create the strategic scenarios. As directly accessing fields of composite types is not the best approach, we changed it to to now call the function directly with the time structure.

The PR closes points 1 and 2 of #50.

> [!IMPORTANT]  
> This change is also breaking. I plan to do a last PR related to the documentation updates before registering the version 0.9.